### PR TITLE
Fix noise overlay camera coordinates

### DIFF
--- a/src/components/GameCanvas.tsx
+++ b/src/components/GameCanvas.tsx
@@ -117,15 +117,22 @@ const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interi
     const syncNoiseOverlayView = (cameraX: number, cameraY: number, zoom: number) => {
         const hasApi = !!NoiseZoning && typeof NoiseZoning.setView === 'function';
         if (!hasApi) return;
+        let worldCamX = cameraX;
+        let worldCamY = cameraY;
+        if ((config.render as any).mode === 'isometric') {
+            const worldCam = isoToWorld({ x: cameraX, y: cameraY });
+            worldCamX = worldCam.x;
+            worldCamY = worldCam.y;
+        }
         const prev = noiseOverlayViewRef.current;
         const changed = !prev
-            || Math.abs(prev.cameraX - cameraX) > 0.5
-            || Math.abs(prev.cameraY - cameraY) > 0.5
+            || Math.abs(prev.cameraX - worldCamX) > 0.5
+            || Math.abs(prev.cameraY - worldCamY) > 0.5
             || Math.abs(prev.zoom - zoom) > 0.005;
         if (!changed) return;
         try {
-            NoiseZoning.setView?.({ cameraX, cameraY, zoom });
-            noiseOverlayViewRef.current = { cameraX, cameraY, zoom };
+            NoiseZoning.setView?.({ cameraX: worldCamX, cameraY: worldCamY, zoom });
+            noiseOverlayViewRef.current = { cameraX: worldCamX, cameraY: worldCamY, zoom };
             if (NoiseZoning.enabled && typeof NoiseZoning.redraw === 'function') {
                 NoiseZoning.redraw();
             }


### PR DESCRIPTION
## Summary
- convert camera coordinates from isometric space back to world space before syncing the Perlin noise overlay
- ensure the overlay cache comparison and update logic use the corrected world coordinates to prevent the pattern from following the character

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cea0d816bc832aa1172809bce76379