### PR TITLE
Add cracked roads toggle to control Perlin noise outlines

### DIFF
--- a/src/components/ToggleButton.tsx
+++ b/src/components/ToggleButton.tsx
@@ -1,23 +1,33 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 interface ToggleButtonProps {
     onText: string;
     offText: string;
-    action: () => void;
+    action: (nextState: boolean) => void;
+    initialState?: boolean;
+    forcedState?: boolean;
 }
 
-const ToggleButton: React.FC<ToggleButtonProps> = ({ onText, offText, action }) => {
-    const [toggleState, setToggleState] = useState(false);
+const ToggleButton: React.FC<ToggleButtonProps> = ({ onText, offText, action, initialState = false, forcedState }) => {
+    const [toggleState, setToggleState] = useState(initialState);
+
+    useEffect(() => {
+        if (typeof forcedState === 'boolean') {
+            setToggleState(forcedState);
+        }
+    }, [forcedState]);
+
+    const effectiveState = typeof forcedState === 'boolean' ? forcedState : toggleState;
 
     const onButtonClick = () => {
-        const newToggleState = !toggleState;
+        const newToggleState = !effectiveState;
         setToggleState(newToggleState);
-        action();
+        action(newToggleState);
     };
 
     return (
         <button onClick={onButtonClick}>
-            {toggleState ? onText : offText}
+            {effectiveState ? onText : offText}
         </button>
     );
 };

--- a/src/game_modules/config.ts
+++ b/src/game_modules/config.ts
@@ -287,6 +287,7 @@ export const config = {
     showBlockOutlines: true,
     // Show warped-noise delimitations (separate toggle for noise regions / buckets)
     showNoiseDelimitations: false,
+    showCrackedRoadsOutline: false,
     // Mostrar apenas os contornos dos quarteirões (esconde ruas e preenchimento dos prédios)
     showOnlyBlockOutlines: false,
     // Mostrar apenas o interior dos quarteirões (preenchidos), escondendo ruas e demais elementos


### PR DESCRIPTION
## Summary
- add a "Mostrar Ruas Rachadas" toggle to the HUD that enables the Perlin noise road contour overlay and keeps it in sync with the overlay module
- extend the reusable toggle button to support controlled state so HUD controls reflect the underlying config
- add a render config flag to remember whether cracked road outlines should be drawn

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cead957f88832a9f20f7e681c579b9