### PR TITLE
Add toggle for cracked road outlines

### DIFF
--- a/src/components/OverlayToggle.tsx
+++ b/src/components/OverlayToggle.tsx
@@ -4,7 +4,13 @@ import NoiseZoning from '../overlays/NoiseZoning';
 const OverlayToggle: React.FC = () => {
   const [enabled, setEnabled] = React.useState(NoiseZoning.enabled);
   const [threshold, setThreshold] = React.useState<number>(NoiseZoning.getNoiseThreshold ? NoiseZoning.getNoiseThreshold() : 0.5);
-  const [outlineOn, setOutlineOn] = React.useState<boolean>(NoiseZoning.getIntersectionOutlineEnabled ? NoiseZoning.getIntersectionOutlineEnabled() : false);
+  const [crackedOn, setCrackedOn] = React.useState<boolean>(
+    NoiseZoning.getCrackedRoadOutlineEnabled
+      ? NoiseZoning.getCrackedRoadOutlineEnabled()
+      : NoiseZoning.getIntersectionOutlineEnabled
+        ? NoiseZoning.getIntersectionOutlineEnabled()
+        : false
+  );
 
   const onToggle = () => {
     NoiseZoning.toggle();
@@ -25,7 +31,7 @@ const OverlayToggle: React.FC = () => {
     const outlineHandler = (event: Event) => {
       const detail = (event as CustomEvent<{ outline?: boolean }>).detail;
       if (detail && typeof detail.outline === 'boolean') {
-        setOutlineOn(detail.outline);
+        setCrackedOn(detail.outline);
       }
     };
     window.addEventListener('noise-overlay-change', handler as EventListener);
@@ -42,10 +48,14 @@ const OverlayToggle: React.FC = () => {
     if (NoiseZoning.setNoiseThreshold) NoiseZoning.setNoiseThreshold(v);
   };
 
-  const onToggleOutline = () => {
-    const next = !outlineOn;
-    setOutlineOn(next);
-    if (NoiseZoning.setIntersectionOutlineEnabled) NoiseZoning.setIntersectionOutlineEnabled(next);
+  const onToggleCracked = () => {
+    const next = !crackedOn;
+    setCrackedOn(next);
+    if (NoiseZoning.setCrackedRoadOutlineEnabled) {
+      NoiseZoning.setCrackedRoadOutlineEnabled(next);
+    } else if (NoiseZoning.setIntersectionOutlineEnabled) {
+      NoiseZoning.setIntersectionOutlineEnabled(next);
+    }
   };
 
   return (
@@ -58,7 +68,7 @@ const OverlayToggle: React.FC = () => {
         <div style={{ width: 36, textAlign: 'right', fontSize: 12 }}>{threshold.toFixed(2)}</div>
       </div>
       <div style={{ display: 'flex', alignItems: 'center' }}>
-        <button onClick={onToggleOutline}>{outlineOn ? 'Esconder Contorno' : 'Mostrar Contorno'}</button>
+        <button onClick={onToggleCracked}>{crackedOn ? 'Esconder Ruas Rachadas' : 'Mostrar Ruas Rachadas'}</button>
       </div>
     </div>
   );

--- a/src/overlays/NoiseZoning.ts
+++ b/src/overlays/NoiseZoning.ts
@@ -50,6 +50,8 @@ export type NoiseZoningAPI = {
   getNoiseThreshold?: () => number;
   setIntersectionOutlineEnabled?: (on: boolean) => void;
   getIntersectionOutlineEnabled?: () => boolean;
+  setCrackedRoadOutlineEnabled?: (on: boolean) => void;
+  getCrackedRoadOutlineEnabled?: () => boolean;
   setPixelSize?: (px: number) => void;
   getPixelSize?: () => number;
 };
@@ -701,6 +703,18 @@ const NoiseZoning: InternalNoiseZoning = {
   },
   getIntersectionOutlineEnabled() {
     return !!(this as any)._showIntersectionOutline;
+  },
+  setCrackedRoadOutlineEnabled(on: boolean) {
+    if (typeof this.setIntersectionOutlineEnabled === 'function') {
+      this.setIntersectionOutlineEnabled(on);
+    } else {
+      (this as any)._showIntersectionOutline = !!on;
+    }
+  },
+  getCrackedRoadOutlineEnabled() {
+    return typeof this.getIntersectionOutlineEnabled === 'function'
+      ? this.getIntersectionOutlineEnabled()
+      : !!(this as any)._showIntersectionOutline;
   },
 };
 


### PR DESCRIPTION
## Summary
- expose a dedicated NoiseZoning API for toggling cracked road outlines
- update the overlay controls to show the new "Mostrar Ruas Rachadas" toggle button

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cead957f88832a9f20f7e681c579b9