### PR TITLE
Fix noise overlay mask alignment when moving noise

### DIFF
--- a/src/overlays/NoiseZoning.ts
+++ b/src/overlays/NoiseZoning.ts
@@ -423,7 +423,18 @@ const NoiseZoning: InternalNoiseZoning = {
     try {
       // cache key based on view
       const maskCache = (this as any)._maskCache as any | undefined;
-      if (maskCache && maskCache.w === coarseW && maskCache.h === coarseH && maskCache.cameraX === cameraX && maskCache.cameraY === cameraY && maskCache.zoom === zoom) {
+      if (
+        maskCache &&
+        maskCache.w === coarseW &&
+        maskCache.h === coarseH &&
+        maskCache.cameraX === cameraX &&
+        maskCache.cameraY === cameraY &&
+        maskCache.zoom === zoom &&
+        maskCache.minPx === minPx &&
+        maskCache.minPy === minPy &&
+        maskCache.maxPx === maxPx &&
+        maskCache.maxPy === maxPy
+      ) {
         // reuse
         const src = maskCache.data;
         for (let i = 0; i < coarseRoadMask.length; i++) coarseRoadMask[i] = src[i];
@@ -468,7 +479,18 @@ const NoiseZoning: InternalNoiseZoning = {
           }
         }
         // cache
-        (this as any)._maskCache = { w: coarseW, h: coarseH, cameraX, cameraY, zoom, data: new Uint8Array(coarseRoadMask) };
+        (this as any)._maskCache = {
+          w: coarseW,
+          h: coarseH,
+          cameraX,
+          cameraY,
+          zoom,
+          minPx,
+          minPy,
+          maxPx,
+          maxPy,
+          data: new Uint8Array(coarseRoadMask),
+        };
         maskOk = true;
       }
     } catch (e) {


### PR DESCRIPTION
## Summary
- guard the cached road mask against view bound changes so it always matches the current noise grid
- persist the bounding box metadata with the cache to keep masks anchored to the roads when noise shifts

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ceb9ea4b74832a99f3473dc42ec15b