### PR TITLE
Reduce noise overlay drift when panning

### DIFF
--- a/src/components/GameCanvas.tsx
+++ b/src/components/GameCanvas.tsx
@@ -118,10 +118,13 @@ const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interi
         const hasApi = !!NoiseZoning && typeof NoiseZoning.setView === 'function';
         if (!hasApi) return;
         const prev = noiseOverlayViewRef.current;
+        const safeZoom = Math.max(zoom, 1e-6);
+        const movedPxX = prev ? Math.abs(prev.cameraX - cameraX) * safeZoom : Infinity;
+        const movedPxY = prev ? Math.abs(prev.cameraY - cameraY) * safeZoom : Infinity;
         const changed = !prev
-            || Math.abs(prev.cameraX - cameraX) > 0.5
-            || Math.abs(prev.cameraY - cameraY) > 0.5
-            || Math.abs(prev.zoom - zoom) > 0.005;
+            || movedPxX > 0.1
+            || movedPxY > 0.1
+            || Math.abs(prev.zoom - zoom) > 0.001;
         if (!changed) return;
         try {
             NoiseZoning.setView?.({ cameraX, cameraY, zoom });


### PR DESCRIPTION
## Summary
- tighten the noise overlay synchronization tolerance so redraws happen once the camera moves roughly a tenth of a screen pixel
- ensure the overlay zoom tolerance is smaller to avoid visible lag between the noise field and road masks

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ceba5c2c14832abc0799a2b3b2ce65