### PR TITLE
Fix noise overlay mask jitter

### DIFF
--- a/src/overlays/NoiseZoning.ts
+++ b/src/overlays/NoiseZoning.ts
@@ -374,9 +374,27 @@ const NoiseZoning: InternalNoiseZoning = {
     }
     const coarse = new Float32Array(coarseW * coarseH);
     const coarseRoadMask = new Uint8Array(coarseW * coarseH); // 0/1 mask indicating presence of road
-    // pixel size of each coarse cell (in screen px)
     const cellPxW = regionPxW / Math.max(1, coarseW);
     const cellPxH = regionPxH / Math.max(1, coarseH);
+    const buildEdges = (count: number, start: number, span: number) => {
+      const edges = new Float32Array(Math.max(0, count) + 1);
+      if (count <= 0) {
+        edges[0] = start;
+        return edges;
+      }
+      edges[0] = start;
+      let acc = start;
+      const step = span / count;
+      for (let i = 1; i < count; i++) {
+        acc += step;
+        const rounded = Math.round(acc);
+        edges[i] = rounded <= edges[i - 1] ? edges[i - 1] : rounded;
+      }
+      edges[count] = start + span;
+      return edges;
+    };
+    const xEdges = buildEdges(coarseW, minPx, regionPxW);
+    const yEdges = buildEdges(coarseH, minPy, regionPxH);
     // helper: convert screen px -> world coords (handles isometric)
     // Precompute sample positions: sample at center of each coarse cell in screen-space, map back to world and sample noise
     const safeZoom = Math.max(zoom, 1e-6);
@@ -408,10 +426,14 @@ const NoiseZoning: InternalNoiseZoning = {
       };
     };
     for (let gy = 0; gy < coarseH; gy++) {
-      const sampleScreenY = minPy + (gy + 0.5) * cellPxH;
+      const y0 = yEdges[Math.max(gy, 0)];
+      const y1 = yEdges[Math.min(gy + 1, yEdges.length - 1)];
+      const sampleScreenY = (y0 + y1) * 0.5;
       for (let gx = 0; gx < coarseW; gx++) {
         const idx = gy * coarseW + gx;
-        const sampleScreenX = minPx + (gx + 0.5) * cellPxW;
+        const x0 = xEdges[Math.max(gx, 0)];
+        const x1 = xEdges[Math.min(gx + 1, xEdges.length - 1)];
+        const sampleScreenX = (x0 + x1) * 0.5;
         const { x: worldX, y: worldY } = screenToWorld(sampleScreenX, sampleScreenY);
         coarse[idx] = sampleWarpedNoise(this._noise, worldX * baseScale, worldY * baseScale, octaves, lacunarity, gain);
       }
@@ -448,7 +470,10 @@ const NoiseZoning: InternalNoiseZoning = {
           const A = projectWorldToScreen(seg.r.start);
           const B = projectWorldToScreen(seg.r.end);
           // Map screen px -> coarse canvas coords
-          const toCoarse = (screenPt: { x: number; y: number }) => ({ x: (screenPt.x - minPx) / cellPxW, y: (screenPt.y - minPy) / cellPxH });
+          const toCoarse = (screenPt: { x: number; y: number }) => ({
+            x: ((screenPt.x - minPx) * coarseW) / Math.max(1e-6, regionPxW),
+            y: ((screenPt.y - minPy) * coarseH) / Math.max(1e-6, regionPxH),
+          });
           const a = toCoarse(A);
           const b = toCoarse(B);
           const strokePx = Math.max(1, (seg.width || 1) / Math.max(1e-6, Math.min(cellPxW, cellPxH)));
@@ -506,20 +531,18 @@ const NoiseZoning: InternalNoiseZoning = {
       const aNorm = (alpha / 255) || 0;
       this._ctx.fillStyle = `rgba(0,0,0,${aNorm})`;
 
-      // compute pixel size of each coarse cell
-      const cellPxW = (maxPx - minPx + 1) / Math.max(1, coarseW);
-      const cellPxH = (maxPy - minPy + 1) / Math.max(1, coarseH);
-
       for (let gy = 0; gy < coarseH; gy++) {
-        const y0 = Math.round(minPy + gy * cellPxH);
-        const hPx = Math.max(1, Math.round((gy === coarseH - 1) ? (maxPy - minPy + 1) - Math.round(gy * cellPxH) : cellPxH));
+        const y0 = Math.round(yEdges[Math.max(gy, 0)]);
+        const y1 = Math.round(yEdges[Math.min(gy + 1, yEdges.length - 1)]);
+        const hPx = Math.max(1, y1 - y0);
         for (let gx = 0; gx < coarseW; gx++) {
           const i = gy * coarseW + gx;
           if (!coarseRoadMask[i]) continue; // skip non-road blocks
           const n = coarse[i];
           if (n <= noiseThreshold) continue;
-          const x0 = Math.round(minPx + gx * cellPxW);
-          const wPx = Math.max(1, Math.round((gx === coarseW - 1) ? (maxPx - minPx + 1) - Math.round(gx * cellPxW) : cellPxW));
+          const x0 = Math.round(xEdges[Math.max(gx, 0)]);
+          const x1 = Math.round(xEdges[Math.min(gx + 1, xEdges.length - 1)]);
+          const wPx = Math.max(1, x1 - x0);
           // draw block
           this._ctx.fillRect(x0, y0, wPx, hPx);
         }
@@ -542,9 +565,25 @@ const NoiseZoning: InternalNoiseZoning = {
       } else {
         const minCellSizePx = Math.max(1, Math.min(cellPxW, cellPxH));
         const polygons: number[][][] = [];
+        const findIndex = (edges: Float32Array, value: number) => {
+          if (value < edges[0] || value > edges[edges.length - 1]) return -1;
+          let lo = 0;
+          let hi = edges.length - 1;
+          while (lo < hi) {
+            const mid = (lo + hi) >> 1;
+            if (value < edges[mid]) {
+              hi = mid;
+            } else {
+              lo = mid + 1;
+            }
+          }
+          const idx = lo - 1;
+          if (idx < 0) return -1;
+          return Math.min(edges.length - 2, idx);
+        };
         const pointHitsIntersection = (pt: { x: number; y: number }) => {
-          const gx = Math.floor((pt.x - minPx) / cellPxW);
-          const gy = Math.floor((pt.y - minPy) / cellPxH);
+          const gx = findIndex(xEdges, pt.x);
+          const gy = findIndex(yEdges, pt.y);
           if (gx < 0 || gy < 0 || gx >= coarseW || gy >= coarseH) return false;
           return intersectionMask[gy * coarseW + gx] > 0;
         };
@@ -825,11 +864,11 @@ const NoiseZoning: InternalNoiseZoning = {
 
 // marching squares: extract contours from binary grid (values 0/1)
 
-function marchingSquaresContoursScreen(grid: Uint8Array, w: number, h: number, minPx: number, minPy: number, cellPxW: number, cellPxH: number) {
+function marchingSquaresContoursScreen(grid: Uint8Array, w: number, h: number, xEdges: Float32Array, yEdges: Float32Array) {
   const segments: Array<[[number, number], [number, number]]> = [];
   const get = (x: number, y: number) => (x >= 0 && y >= 0 && x < w && y < h) ? (grid[y * w + x] ? 1 : 0) : 0;
-  const sx = (gx: number) => minPx + gx * cellPxW;
-  const sy = (gy: number) => minPy + gy * cellPxH;
+  const sx = (gx: number) => xEdges[Math.max(0, Math.min(xEdges.length - 1, gx))];
+  const sy = (gy: number) => yEdges[Math.max(0, Math.min(yEdges.length - 1, gy))];
   for (let y = 0; y < h - 1; y++) {
     for (let x = 0; x < w - 1; x++) {
       const tl = get(x, y);


### PR DESCRIPTION
## Summary
- align noise sampling and drawing to shared coarse grid edges so the road mask no longer drifts when noise values change
- update mask rasterization and intersection queries to reuse the precomputed edges for stable screen-to-grid mapping
- adjust the marching-squares helper to accept the new edge data for consistent outline rendering

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68ceb9ea4b74832a99f3473dc42ec15b