### PR TITLE
Add cracked road configuration panel

### DIFF
--- a/src/components/GameCanvas.tsx
+++ b/src/components/GameCanvas.tsx
@@ -3161,9 +3161,11 @@ const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interi
         const onNoiseMaskUpdated = () => { scheduleCrackedRoadRedraw(); };
         const onNoiseOverlayToggle = () => { scheduleCrackedRoadRedraw(); };
         const onNoiseOutlineToggle = () => { scheduleCrackedRoadRedraw(); };
+        const onCrackedConfigChange = () => { scheduleCrackedRoadRedraw(); };
         window.addEventListener('noise-overlay-intersection-updated', onNoiseMaskUpdated as EventListener);
         window.addEventListener('noise-overlay-change', onNoiseOverlayToggle as EventListener);
         window.addEventListener('noise-overlay-outline-change', onNoiseOutlineToggle as EventListener);
+        window.addEventListener('cracked-roads-config-change', onCrackedConfigChange as EventListener);
 
         const handleResize = () => {
             if (!canvasContainerRef.current) return;
@@ -3518,6 +3520,7 @@ const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interi
             window.removeEventListener('noise-overlay-intersection-updated', onNoiseMaskUpdated as EventListener);
             window.removeEventListener('noise-overlay-change', onNoiseOverlayToggle as EventListener);
             window.removeEventListener('noise-overlay-outline-change', onNoiseOutlineToggle as EventListener);
+            window.removeEventListener('cracked-roads-config-change', onCrackedConfigChange as EventListener);
             if (crackedRoadsRaf.current != null && typeof window !== 'undefined' && typeof window.cancelAnimationFrame === 'function') {
                 window.cancelAnimationFrame(crackedRoadsRaf.current);
                 crackedRoadsRaf.current = null;


### PR DESCRIPTION
## Summary
- add a floating “Config. Ruas Rachadas” panel that lets the user tweak color, opacity, densities, limits and reset defaults for the cracked roads overlay
- sync cracked road settings back into the render config and broadcast changes so the PIXI overlay redraws immediately
- listen for the new cracked-roads-config-change event inside GameCanvas to trigger redraws when settings change

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cef341c418832ab4eab369bd1dab72