### PR TITLE
Enable cracked road overlays without noise toggle

### DIFF
--- a/src/components/GameCanvas.tsx
+++ b/src/components/GameCanvas.tsx
@@ -1202,18 +1202,22 @@ const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interi
         container.removeChildren();
         const cfg = (config as any).render;
         const show = !!cfg.showCrackedRoadsOutline;
-        const overlayEnabled = !!NoiseZoning?.enabled;
-        if (!show || !overlayEnabled) {
+        if (!show) {
             container.visible = false;
             return;
         }
         const getMask = (NoiseZoning as any)?.getIntersectionMaskData;
         const createTester = (NoiseZoning as any)?.createIntersectionTester;
-        if (typeof getMask !== 'function' || typeof createTester !== 'function') {
+        if (typeof createTester !== 'function') {
             container.visible = false;
             return;
         }
-        const maskInfo = getMask.call(NoiseZoning) as {
+        const tester = createTester.call(NoiseZoning) as ((x: number, y: number) => boolean) | null;
+        if (!tester) {
+            container.visible = false;
+            return;
+        }
+        const maskInfo = typeof getMask === 'function' ? getMask.call(NoiseZoning) as {
             coarseW: number;
             coarseH: number;
             gridMinX: number;
@@ -1221,9 +1225,8 @@ const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interi
             worldStep: number;
             pixelSizePx: number;
             intersectionMask: Uint8Array;
-        } | null;
-        const tester = createTester.call(NoiseZoning) as ((x: number, y: number) => boolean) | null;
-        if (!maskInfo || !tester || !(maskInfo.worldStep > 0)) {
+        } | null : null;
+        if (!maskInfo || !(maskInfo.worldStep > 0)) {
             container.visible = false;
             return;
         }

--- a/src/game_modules/config.ts
+++ b/src/game_modules/config.ts
@@ -287,7 +287,7 @@ export const config = {
     showBlockOutlines: true,
     // Show warped-noise delimitations (separate toggle for noise regions / buckets)
     showNoiseDelimitations: false,
-    showCrackedRoadsOutline: false,
+    showCrackedRoadsOutline: true,
     crackedRoadColor: 0x00E5FF,
     crackedRoadAlpha: 0.88,
     crackedRoadStrokePx: 1.35,


### PR DESCRIPTION
## Summary
- make cracked road rendering independent from the noise overlay toggle so the cracks always draw when enabled in the config
- default the cracked road overlay setting to on so newly generated maps show the cracks automatically

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68cef88c1284832ab8d621166229b5a6