### PR TITLE
Enable cracked roads without Perlin toggle

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -25,15 +25,20 @@ const App: React.FC = () => {
     });
     const [crackedRoadsVisible, setCrackedRoadsVisible] = useState<boolean>(() => {
         try {
-            if (typeof NoiseZoning.getIntersectionOutlineEnabled === 'function') {
-                return !!NoiseZoning.getIntersectionOutlineEnabled();
+            const cfgValue = (config as any).render?.showCrackedRoadsOutline;
+            if (typeof cfgValue === 'boolean') {
+                return cfgValue;
             }
         } catch (e) {}
         try {
-            return !!((config as any).render?.showCrackedRoadsOutline);
-        } catch (e) {
-            return false;
-        }
+            if (typeof NoiseZoning.getIntersectionOutlineEnabled === 'function') {
+                const zoneValue = NoiseZoning.getIntersectionOutlineEnabled();
+                if (typeof zoneValue === 'boolean') {
+                    return zoneValue;
+                }
+            }
+        } catch (e) {}
+        return true;
     });
     const [uiTick, setUiTick] = useState(0); // força re-render para atualizar HUD
     const [outlineMode, setOutlineMode] = useState((config as any).render.roadOutlineMode);

--- a/src/components/GameCanvas.tsx
+++ b/src/components/GameCanvas.tsx
@@ -1202,8 +1202,7 @@ const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interi
         container.removeChildren();
         const cfg = (config as any).render;
         const show = !!cfg.showCrackedRoadsOutline;
-        const overlayEnabled = !!NoiseZoning?.enabled;
-        if (!show || !overlayEnabled) {
+        if (!show) {
             container.visible = false;
             return;
         }

--- a/src/game_modules/config.ts
+++ b/src/game_modules/config.ts
@@ -287,7 +287,7 @@ export const config = {
     showBlockOutlines: true,
     // Show warped-noise delimitations (separate toggle for noise regions / buckets)
     showNoiseDelimitations: false,
-    showCrackedRoadsOutline: false,
+    showCrackedRoadsOutline: true,
     crackedRoadColor: 0x00E5FF,
     crackedRoadAlpha: 0.88,
     crackedRoadStrokePx: 1.35,


### PR DESCRIPTION
## Summary
- default cracked road overlay visibility to on in configuration and state initialisation
- decouple cracked-road drawing from the Perlin overlay enable flag so fissures render whenever mask data exists

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cef88c1284832ab8d621166229b5a6