### PR TITLE
Improve cracks demo with stylized isometric rendering

### DIFF
--- a/public/cracks_streets.html
+++ b/public/cracks_streets.html
@@ -2,103 +2,618 @@
 <html lang="pt-BR">
 <head>
   <meta charset="UTF-8">
-  <title>Ruas — Bordas (Cinza Escuro)</title>
+  <title>Rachaduras — Vista Isométrica</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <style>
+    :root {
+      --bg: #0f141b;
+      --panel: #1a212b;
+      --border: rgba(15, 30, 45, 0.65);
+      --accent: #00d4ff;
+      --accent-soft: #7fe8ff;
+      --ink: #e6f3ff;
+      --muted: #9ba8b6;
+    }
+
+    * { box-sizing: border-box; }
+
     body {
-      background: #202020;
+      margin: 0;
+      min-height: 100vh;
+      font-family: "Inter", system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+      background: radial-gradient(circle at 20% -10%, rgba(0, 212, 255, 0.15), transparent 40%),
+                  radial-gradient(circle at 80% 0%, rgba(0, 163, 255, 0.12), transparent 45%),
+                  var(--bg);
+      color: var(--ink);
+      display: flex;
+      align-items: stretch;
+      justify-content: center;
+      padding: 24px 16px 36px;
+    }
+
+    .wrap {
+      display: grid;
+      gap: 18px;
+      width: min(1080px, 100%);
+      grid-template-columns: 340px 1fr;
+    }
+
+    @media (max-width: 980px) {
+      .wrap {
+        grid-template-columns: 1fr;
+      }
+    }
+
+    .panel {
+      background: linear-gradient(165deg, rgba(20, 29, 38, 0.92), rgba(12, 17, 23, 0.95));
+      border: 1px solid var(--border);
+      border-radius: 16px;
+      box-shadow: 0 22px 45px rgba(0, 6, 15, 0.45);
+      padding: 20px 22px;
+    }
+
+    h1 {
+      margin: 0 0 6px;
+      font-size: 20px;
+      letter-spacing: 0.4px;
+      font-weight: 600;
+    }
+
+    .hint {
+      margin: 0 0 18px;
+      font-size: 13px;
+      line-height: 1.5;
+      color: var(--muted);
+    }
+
+    .control-grid {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 12px 14px;
+    }
+
+    .control-grid label {
       display: flex;
       flex-direction: column;
-      justify-content: center;
-      align-items: center;
-      height: 100vh;
-      margin: 0;
-      gap: 10px;
-      font-family: system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
-      color: #ddd;
+      gap: 6px;
+      font-size: 12px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.06em;
+      color: #b9c4d2;
     }
-    canvas { border: 2px solid #111; image-rendering: pixelated; }
-    .legend { color:#ddd; font-size:13px; }
-    .sw { width:12px; height:12px; display:inline-block; border-radius:3px; margin-right:6px; box-shadow:0 0 0 1px rgba(0,0,0,.25) inset; }
-    .controls { display:flex; gap:12px; align-items:center; }
-    input[type=range] { width:240px; }
+
+    .value {
+      font-size: 11px;
+      font-weight: 600;
+      letter-spacing: 0.04em;
+      color: var(--accent-soft);
+    }
+
+    input[type="range"] {
+      appearance: none;
+      width: 100%;
+      height: 6px;
+      border-radius: 999px;
+      background: rgba(255, 255, 255, 0.08);
+      overflow: hidden;
+    }
+
+    input[type="range"]::-webkit-slider-thumb {
+      appearance: none;
+      width: 16px;
+      height: 16px;
+      border-radius: 50%;
+      background: var(--accent);
+      box-shadow: 0 0 0 4px rgba(0, 212, 255, 0.18);
+      border: 0;
+      cursor: pointer;
+    }
+
+    input[type="range"]::-moz-range-thumb {
+      width: 16px;
+      height: 16px;
+      border-radius: 50%;
+      background: var(--accent);
+      border: 0;
+      cursor: pointer;
+    }
+
+    input[type="number"] {
+      width: 100%;
+      padding: 8px 10px;
+      border-radius: 10px;
+      border: 1px solid rgba(0, 214, 255, 0.18);
+      background: rgba(0, 12, 20, 0.55);
+      color: var(--ink);
+      font-size: 14px;
+    }
+
+    .row {
+      display: flex;
+      gap: 10px;
+      margin: 20px 0 16px;
+      flex-wrap: wrap;
+    }
+
+    button {
+      flex: 1;
+      min-width: 120px;
+      border: 0;
+      border-radius: 12px;
+      padding: 10px 14px;
+      background: linear-gradient(135deg, rgba(0, 212, 255, 0.85), rgba(0, 116, 220, 0.9));
+      color: #00131c;
+      font-weight: 600;
+      letter-spacing: 0.04em;
+      cursor: pointer;
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+      box-shadow: 0 12px 20px rgba(0, 173, 239, 0.28);
+    }
+
+    button:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 18px 28px rgba(0, 173, 239, 0.35);
+    }
+
+    button:active {
+      transform: translateY(0);
+      box-shadow: 0 10px 18px rgba(0, 173, 239, 0.25);
+    }
+
+    .mini {
+      font-size: 12px;
+      color: var(--muted);
+      letter-spacing: 0.03em;
+    }
+
+    .canvas-panel {
+      position: relative;
+      padding: 16px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: radial-gradient(circle at 50% 35%, rgba(0, 212, 255, 0.08), rgba(0, 60, 80, 0.06) 32%, rgba(0, 8, 12, 0.35) 70%),
+                  linear-gradient(165deg, rgba(12, 18, 26, 0.85), rgba(7, 10, 14, 0.95));
+    }
+
+    canvas#canvas {
+      width: 100%;
+      height: auto;
+      max-width: 720px;
+      border-radius: 18px;
+      border: 1px solid rgba(0, 212, 255, 0.18);
+      background: #05070c;
+      box-shadow: 0 25px 40px rgba(0, 11, 18, 0.55);
+    }
+
+    canvas#preview {
+      position: absolute;
+      right: 26px;
+      bottom: 26px;
+      width: 168px;
+      height: 168px;
+      border-radius: 16px;
+      border: 1px solid rgba(0, 212, 255, 0.25);
+      background: rgba(5, 9, 12, 0.9);
+      box-shadow: 0 20px 30px rgba(0, 10, 16, 0.55);
+      image-rendering: pixelated;
+    }
+
+    @media (max-width: 640px) {
+      canvas#preview {
+        position: static;
+        width: 140px;
+        height: 140px;
+        margin-top: 18px;
+      }
+
+      .canvas-panel {
+        flex-direction: column;
+      }
+    }
   </style>
 </head>
 <body>
-  <canvas id="canvas" width="512" height="512"></canvas>
-  <div class="controls">
-    <div class="legend"><i class="sw" style="background:#3a3a3a"></i>Ruas (cinza escuro)</div>
-    <label style="font-size:13px">Largura: <span id="thVal">1.6</span></label>
-    <input id="th" type="range" min="0.2" max="6" step="0.1" value="1.6">
-    <button id="regenerate">Regenerar</button>
+  <div class="wrap">
+    <section class="panel">
+      <h1>Rachaduras Procedurais</h1>
+      <p class="hint">As fissuras são geradas pelas bordas do diagrama de Voronoi. Ajuste a espessura (ε), o halo e a quantidade de sementes para esculpir o padrão. O resultado é renderizado diretamente em uma placa isométrica pronta para usar como textura.</p>
+      <div class="control-grid">
+        <label>Seeds
+          <input id="num" type="range" min="40" max="360" value="180">
+          <span class="value" id="numv">180</span>
+        </label>
+        <label>Espessura (ε)
+          <input id="eps" type="range" min="4" max="30" value="12">
+          <span class="value" id="epsv">1.2</span>
+        </label>
+        <label>Halo Suave
+          <input id="halo" type="range" min="10" max="80" value="36">
+          <span class="value" id="halov">3.6</span>
+        </label>
+        <label>Brilho
+          <input id="shine" type="range" min="0" max="100" value="58">
+          <span class="value" id="shinev">0.58</span>
+        </label>
+        <label>Rugosidade
+          <input id="rough" type="range" min="0" max="100" value="28">
+          <span class="value" id="roughv">0.28</span>
+        </label>
+        <label>Semente aleatória
+          <input id="seed" type="number" min="0" max="4294967295" step="1" value="123456789">
+        </label>
+      </div>
+      <div class="row">
+        <button id="regen">Regenerar</button>
+        <button id="reroll">Nova semente</button>
+        <button id="save">Exportar PNG</button>
+      </div>
+      <p class="mini" id="info">—</p>
+    </section>
+    <section class="panel canvas-panel">
+      <canvas id="canvas" width="720" height="520"></canvas>
+      <canvas id="preview" width="192" height="192"></canvas>
+    </section>
   </div>
 
   <script>
-    const N = 512;
-    const numPoints = 80;
-    const EDGE_COLOR = [58,58,58]; // cinza escuro
+    const SIZE = 512;
+    const ISO = { A: 1, B: 0.5, C: -1, D: 0.5 };
 
-    const canvas = document.getElementById('canvas');
-    const ctx = canvas.getContext('2d');
+    const isoCanvas = document.getElementById('canvas');
+    const isoCtx = isoCanvas.getContext('2d');
+    const previewCanvas = document.getElementById('preview');
+    const previewCtx = previewCanvas.getContext('2d');
 
-    let pts = generatePoints();
+    const hiddenCanvas = document.createElement('canvas');
+    hiddenCanvas.width = hiddenCanvas.height = SIZE;
+    const hiddenCtx = hiddenCanvas.getContext('2d', { willReadFrequently: true });
 
-    function generatePoints(){
-      return Array.from({length: numPoints}, () => [Math.random()*N, Math.random()*N]);
-    }
+    const numEl = document.getElementById('num');
+    const epsEl = document.getElementById('eps');
+    const haloEl = document.getElementById('halo');
+    const shineEl = document.getElementById('shine');
+    const roughEl = document.getElementById('rough');
+    const seedEl = document.getElementById('seed');
 
-    function setPixel(data, idx, r, g, b, a=255){
-      data[idx] = r; data[idx+1] = g; data[idx+2] = b; data[idx+3] = a;
-    }
+    const numValEl = document.getElementById('numv');
+    const epsValEl = document.getElementById('epsv');
+    const haloValEl = document.getElementById('halov');
+    const shineValEl = document.getElementById('shinev');
+    const roughValEl = document.getElementById('roughv');
 
-    function drawEdgesOnly(threshold) {
-      const imageData = ctx.createImageData(N, N);
-      const data = imageData.data;
+    const regenBtn = document.getElementById('regen');
+    const rerollBtn = document.getElementById('reroll');
+    const saveBtn = document.getElementById('save');
+    const infoEl = document.getElementById('info');
 
-      for (let y=0; y<N; y++) {
-        for (let x=0; x<N; x++) {
-          const p = (y*N + x) * 4;
+    const state = {
+      seeds: parseInt(numEl.value, 10) || 180,
+      eps: (+epsEl.value || 12) / 10,
+      halo: (+haloEl.value || 36) / 10,
+      shine: (+shineEl.value || 58) / 100,
+      rough: (+roughEl.value || 28) / 100,
+      seed: parseInt(seedEl.value, 10) >>> 0 || 123456789,
+    };
 
-          // compute squared distances to all points to find nearest and second nearest
-          let nearest = -1, d1 = Infinity, second = -1, d2 = Infinity;
-          for (let i=0;i<pts.length;i++){
-            const dx = x-pts[i][0]; const dy = y-pts[i][1];
-            const d = dx*dx + dy*dy;
-            if (d < d1) { d2 = d1; second = nearest; d1 = d; nearest = i; }
-            else if (d < d2) { d2 = d; second = i; }
+    let points = new Float32Array(state.seeds * 2);
+    let grid = [];
+    let gridSize = 0;
+    let cellSize = 0;
+    let allIndices = [];
+    const candidateBuffer = [];
+
+    const clamp = (v, min, max) => Math.max(min, Math.min(max, v));
+    const mix = (a, b, t) => a * (1 - t) + b * t;
+
+    const createPRNG = (seed) => {
+      let a = seed >>> 0;
+      return () => {
+        a = (a + 0x6D2B79F5) | 0;
+        let t = Math.imul(a ^ (a >>> 15), 1 | a);
+        t ^= t + Math.imul(t ^ (t >>> 7), 61 | t);
+        return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+      };
+    };
+
+    const hashNoise = (x, y, seed) => {
+      let h = Math.imul(x + 137, 0x1f123bb5);
+      h = (h ^ Math.imul(y + 73, 0x9e3779b9)) >>> 0;
+      h = (h ^ Math.imul(seed + 53, 0x85ebca6b)) >>> 0;
+      h ^= h >>> 15;
+      h = Math.imul(h, 0xc2b2ae35) >>> 0;
+      h ^= h >>> 13;
+      return (h & 0xffff) / 0xffff;
+    };
+
+    const projectIso = (x, y) => ({
+      x: ISO.A * x + ISO.C * y,
+      y: ISO.B * x + ISO.D * y,
+    });
+
+    const reseedPoints = () => {
+      const rng = createPRNG(state.seed);
+      points = new Float32Array(state.seeds * 2);
+      for (let i = 0; i < state.seeds; i++) {
+        points[2 * i] = rng() * SIZE;
+        points[2 * i + 1] = rng() * SIZE;
+      }
+    };
+
+    const buildGrid = () => {
+      gridSize = Math.max(6, Math.round(Math.sqrt(state.seeds)));
+      cellSize = SIZE / gridSize;
+      grid = new Array(gridSize * gridSize);
+      for (let i = 0; i < grid.length; i++) grid[i] = [];
+      for (let i = 0; i < state.seeds; i++) {
+        const px = points[2 * i];
+        const py = points[2 * i + 1];
+        const gx = clamp(Math.floor(px / cellSize), 0, gridSize - 1);
+        const gy = clamp(Math.floor(py / cellSize), 0, gridSize - 1);
+        grid[gy * gridSize + gx].push(i);
+      }
+      allIndices = Array.from({ length: state.seeds }, (_, i) => i);
+    };
+
+    const gatherCandidates = (x, y) => {
+      const gx = clamp(Math.floor(x / cellSize), 0, gridSize - 1);
+      const gy = clamp(Math.floor(y / cellSize), 0, gridSize - 1);
+      for (let r = 1; r <= 2; r++) {
+        candidateBuffer.length = 0;
+        for (let yy = gy - r; yy <= gy + r; yy++) {
+          if (yy < 0 || yy >= gridSize) continue;
+          for (let xx = gx - r; xx <= gx + r; xx++) {
+            if (xx < 0 || xx >= gridSize) continue;
+            const arr = grid[yy * gridSize + xx];
+            if (arr && arr.length) candidateBuffer.push(...arr);
+          }
+        }
+        if (candidateBuffer.length || r === 2) break;
+      }
+      return candidateBuffer.length ? candidateBuffer : allIndices;
+    };
+
+    const generateImageData = () => {
+      const image = hiddenCtx.createImageData(SIZE, SIZE);
+      const data = image.data;
+      const eps = state.eps;
+      const haloWidth = Math.max(eps * state.halo, eps * 1.5);
+      const baseColor = [0, 210, 255];
+      const highlightColor = [148, 244, 255];
+      const haloColor = [0, 130, 196];
+      const highlightPower = 1.35 + state.shine * 1.25;
+      const basePower = 0.85 + state.shine * 0.35;
+      const haloPower = 1.6 + state.shine * 0.8;
+      const roughness = state.rough;
+      const seedNoise = state.seed & 0xffffffff;
+
+      for (let y = 0; y < SIZE; y++) {
+        for (let x = 0; x < SIZE; x++) {
+          const idx = (y * SIZE + x) * 4;
+          const candidates = gatherCandidates(x, y);
+          let best1 = Infinity;
+          let best2 = Infinity;
+          for (let k = 0; k < candidates.length; k++) {
+            const i = candidates[k];
+            const dx = x - points[2 * i];
+            const dy = y - points[2 * i + 1];
+            const d = dx * dx + dy * dy;
+            if (d < best1) {
+              best2 = best1;
+              best1 = d;
+            } else if (d < best2) {
+              best2 = d;
+            }
+          }
+          if (!(best1 < Infinity && best2 < Infinity)) {
+            data[idx + 3] = 0;
+            continue;
+          }
+          const delta = Math.sqrt(best2) - Math.sqrt(best1);
+          const crackIntensity = clamp(1 - delta / eps, 0, 1);
+          const haloIntensity = clamp(1 - delta / haloWidth, 0, 1);
+          if (haloIntensity <= 0 && crackIntensity <= 0) {
+            data[idx + 3] = 0;
+            continue;
           }
 
-          // distance difference between nearest and second nearest (using sqrt to get real distances)
-          const distDiff = Math.sqrt(d2) - Math.sqrt(d1);
+          const noise = roughness > 0 ? (hashNoise(x, y, seedNoise) - 0.5) * roughness * 0.9 : 0;
+          const intensity = clamp(crackIntensity + noise, 0, 1);
+          const highlightMix = Math.pow(intensity, highlightPower);
+          const haloMix = Math.pow(haloIntensity, haloPower);
+          const bodyMix = Math.pow(intensity, basePower);
 
-          // If the difference is small, we are near an edge (Voronoi boundary). Use threshold to control width.
-          if (distDiff < threshold) {
-            setPixel(data, p, EDGE_COLOR[0], EDGE_COLOR[1], EDGE_COLOR[2], 255);
-          } else {
-            // transparent background so you can overlay on other maps if desired
-            setPixel(data, p, 0, 0, 0, 0);
-          }
+          const r = clamp(
+            mix(baseColor[0], highlightColor[0], highlightMix) + haloColor[0] * Math.pow(haloMix, 1.2) * 0.35,
+            0,
+            255,
+          );
+          const g = clamp(
+            mix(baseColor[1], highlightColor[1], highlightMix) + haloColor[1] * Math.pow(haloMix, 1.2) * 0.35,
+            0,
+            255,
+          );
+          const b = clamp(
+            mix(baseColor[2], highlightColor[2], highlightMix) + haloColor[2] * Math.pow(haloMix, 1.2) * 0.35,
+            0,
+            255,
+          );
+
+          const alpha = clamp(Math.pow(bodyMix, 0.85) * 0.85 + Math.pow(haloMix, 1.8) * 0.45, 0, 1);
+
+          data[idx] = Math.round(r);
+          data[idx + 1] = Math.round(g);
+          data[idx + 2] = Math.round(b);
+          data[idx + 3] = Math.round(alpha * 255);
         }
       }
 
-      ctx.putImageData(imageData, 0, 0);
-    }
+      return image;
+    };
 
-    // UI wiring
-    const thSlider = document.getElementById('th');
-    const thVal = document.getElementById('thVal');
-    const regen = document.getElementById('regenerate');
+    const drawIsoPlate = () => {
+      const { width: W, height: H } = isoCanvas;
+      const scale = W / (SIZE * 2);
+      const centerX = W / 2;
+      const baseY = H * 0.68;
 
-    function render(){
-      const t = parseFloat(thSlider.value);
-      thVal.textContent = t.toFixed(1);
-      drawEdgesOnly(t);
-    }
+      isoCtx.setTransform(1, 0, 0, 1, 0, 0);
+      isoCtx.clearRect(0, 0, W, H);
 
-    thSlider.addEventListener('input', render);
-    regen.addEventListener('click', () => { pts = generatePoints(); render(); });
+      const bg = isoCtx.createLinearGradient(0, 0, 0, H);
+      bg.addColorStop(0, '#0c1219');
+      bg.addColorStop(0.65, '#05080d');
+      bg.addColorStop(1, '#020305');
+      isoCtx.fillStyle = bg;
+      isoCtx.fillRect(0, 0, W, H);
 
-    // initial render
-    render();
+      isoCtx.save();
+      isoCtx.translate(centerX, baseY + 22);
+      isoCtx.scale(scale, scale * 0.55);
+      const shadowGrad = isoCtx.createRadialGradient(0, 0, SIZE * 0.1, 0, 0, SIZE * 0.9);
+      shadowGrad.addColorStop(0, 'rgba(0, 0, 0, 0.22)');
+      shadowGrad.addColorStop(1, 'rgba(0, 0, 0, 0)');
+      isoCtx.fillStyle = shadowGrad;
+      isoCtx.beginPath();
+      isoCtx.arc(0, 0, SIZE * 0.75, 0, Math.PI * 2);
+      isoCtx.fill();
+      isoCtx.restore();
+
+      const corners = [
+        projectIso(0, 0),
+        projectIso(SIZE, 0),
+        projectIso(SIZE, SIZE),
+        projectIso(0, SIZE),
+      ].map((p) => ({ x: centerX + p.x * scale, y: baseY + p.y * scale }));
+
+      const plateGradient = isoCtx.createLinearGradient(centerX, baseY - SIZE * scale * 0.35, centerX, baseY + SIZE * scale * 0.9);
+      plateGradient.addColorStop(0, '#1f2934');
+      plateGradient.addColorStop(0.35, '#131a21');
+      plateGradient.addColorStop(1, '#080c11');
+
+      isoCtx.beginPath();
+      isoCtx.moveTo(corners[0].x, corners[0].y);
+      for (let i = 1; i < corners.length; i++) isoCtx.lineTo(corners[i].x, corners[i].y);
+      isoCtx.closePath();
+      isoCtx.fillStyle = plateGradient;
+      isoCtx.fill();
+
+      const edgeGradient = isoCtx.createLinearGradient(centerX, baseY + SIZE * scale * 0.05, centerX, baseY + SIZE * scale * 0.85);
+      edgeGradient.addColorStop(0, 'rgba(0, 0, 0, 0)');
+      edgeGradient.addColorStop(1, 'rgba(0, 0, 0, 0.35)');
+      isoCtx.save();
+      isoCtx.clip();
+      isoCtx.fillStyle = edgeGradient;
+      isoCtx.fillRect(centerX - SIZE * scale, baseY, SIZE * scale * 2, SIZE * scale);
+      isoCtx.restore();
+
+      isoCtx.save();
+      isoCtx.translate(centerX, baseY);
+      isoCtx.transform(scale * ISO.A, scale * ISO.B, scale * ISO.C, scale * ISO.D, 0, 0);
+      isoCtx.imageSmoothingEnabled = true;
+      isoCtx.drawImage(hiddenCanvas, 0, 0);
+      isoCtx.globalCompositeOperation = 'lighter';
+      isoCtx.globalAlpha = 0.38;
+      isoCtx.filter = 'blur(1.8px)';
+      isoCtx.drawImage(hiddenCanvas, 0, 0);
+      isoCtx.restore();
+
+      isoCtx.globalAlpha = 1;
+      isoCtx.globalCompositeOperation = 'source-over';
+      isoCtx.filter = 'none';
+    };
+
+    const updatePreview = () => {
+      previewCtx.setTransform(1, 0, 0, 1, 0, 0);
+      previewCtx.clearRect(0, 0, previewCanvas.width, previewCanvas.height);
+      previewCtx.fillStyle = '#05080d';
+      previewCtx.fillRect(0, 0, previewCanvas.width, previewCanvas.height);
+      previewCtx.imageSmoothingEnabled = false;
+      previewCtx.drawImage(hiddenCanvas, 0, 0, SIZE, SIZE, 0, 0, previewCanvas.width, previewCanvas.height);
+    };
+
+    const regenerate = (reseed = false) => {
+      if (reseed) {
+        reseedPoints();
+        buildGrid();
+      }
+      const t0 = performance.now();
+      const img = generateImageData();
+      hiddenCtx.putImageData(img, 0, 0);
+      updatePreview();
+      drawIsoPlate();
+      const t1 = performance.now();
+      infoEl.textContent = `Top-down ${SIZE}² • seeds ${state.seeds} • ε=${state.eps.toFixed(1)} • halo=${state.halo.toFixed(1)} • tempo ${Math.round(t1 - t0)} ms`;
+    };
+
+    const syncLabels = () => {
+      numValEl.textContent = `${state.seeds}`;
+      epsValEl.textContent = state.eps.toFixed(1);
+      haloValEl.textContent = state.halo.toFixed(1);
+      shineValEl.textContent = state.shine.toFixed(2);
+      roughValEl.textContent = state.rough.toFixed(2);
+    };
+
+    numEl.addEventListener('input', () => {
+      state.seeds = parseInt(numEl.value, 10) || 40;
+      syncLabels();
+      reseedPoints();
+      buildGrid();
+      regenerate(false);
+    });
+
+    epsEl.addEventListener('input', () => {
+      state.eps = (+epsEl.value || 4) / 10;
+      syncLabels();
+      regenerate(false);
+    });
+
+    haloEl.addEventListener('input', () => {
+      state.halo = (+haloEl.value || 10) / 10;
+      syncLabels();
+      regenerate(false);
+    });
+
+    shineEl.addEventListener('input', () => {
+      state.shine = (+shineEl.value || 0) / 100;
+      syncLabels();
+      regenerate(false);
+    });
+
+    roughEl.addEventListener('input', () => {
+      state.rough = (+roughEl.value || 0) / 100;
+      syncLabels();
+      regenerate(false);
+    });
+
+    seedEl.addEventListener('change', () => {
+      state.seed = parseInt(seedEl.value, 10) >>> 0 || 0;
+      reseedPoints();
+      buildGrid();
+      regenerate(false);
+    });
+
+    regenBtn.addEventListener('click', () => regenerate(true));
+    rerollBtn.addEventListener('click', () => {
+      state.seed = (Math.random() * 0xffffffff) >>> 0;
+      seedEl.value = state.seed.toString();
+      reseedPoints();
+      buildGrid();
+      regenerate(false);
+    });
+
+    saveBtn.addEventListener('click', () => {
+      const link = document.createElement('a');
+      link.href = isoCanvas.toDataURL('image/png');
+      link.download = 'rachaduras_isometricas.png';
+      link.click();
+    });
+
+    syncLabels();
+    reseedPoints();
+    buildGrid();
+    regenerate(false);
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- refresh the cracks_streets.html layout with a darker palette, gradients, and an embedded top-down preview canvas
- add richer controls for seed count, Voronoi thickness, halo, brightness, roughness, and deterministic seeding plus export/regeneration actions
- render Voronoi cracks with color falloff, noise halo, and isometric projection so the output plate is ready for use in the game

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cf1c6d46b4832a8688b9484038ce6c