### PR TITLE
Refine crack overlay with handmade stroke rendering

### DIFF
--- a/src/overlays/NoiseZoning.ts
+++ b/src/overlays/NoiseZoning.ts
@@ -4,8 +4,9 @@
  * Modifications:
  * - Restrict rendering to road areas only by building a coarse road mask using the MapStore quadtree
  *   and distance-to-segment checks. This prevents the noise overlay from showing on non-road areas.
- * - Pixelate the noise by sampling at a coarse grid and using nearest-neighbor lookup when writing
- *   pixels. This gives a blocky/pixelated look instead of smooth organic interpolation.
+ * - Sample the noise on a coarse grid but render it using jittered curved strokes that connect
+ *   active cells. This preserves performance while replacing the previous blocky pixels with a
+ *   hand-drawn aesthetic that feels less digital.
  * API: attach(canvas), toggle(), reseed(), redraw()
  * Independent of roads/buildings
  */
@@ -586,40 +587,137 @@ const NoiseZoning: InternalNoiseZoning = {
     for (let i = 0; i < coarse.length; i++) {
       intersectionMask[i] = (coarse[i] > noiseThreshold && coarseRoadMask[i]) ? 1 : 0;
     }
-    // Pixelated rendering: draw one rect per coarse cell using nearest-neighbor.
-    // This avoids allocating a full ImageData buffer and reduces memory churn.
+    const aNorm = (alpha / 255) || 0;
+    const handmadeCentersX = new Float32Array(coarseW * coarseH);
+    const handmadeCentersY = new Float32Array(coarseW * coarseH);
+    const handmadeStroke = new Float32Array(coarseW * coarseH);
+    const activeCells: number[] = [];
+
+    const baseSeed = Math.floor((this as any)._handSeed ?? this._seed ?? 0);
+    (this as any)._handSeed = baseSeed;
+    const jitterBase = Math.max(0.35, pixelSizePx * 0.45);
+    const strokeBase = Math.max(0.75, pixelSizePx * 0.6);
+
+    const jitterFor = (gridX: number, gridY: number, variant: number) => {
+      const s = Math.sin((gridX * 127.1 + gridY * 311.7 + (baseSeed + variant) * 74.7) * 12.9898) * 43758.5453;
+      return s - Math.floor(s);
+    };
+
+    for (let gy = 0; gy < coarseH; gy++) {
+      const gridY = gridMinY + gy;
+      for (let gx = 0; gx < coarseW; gx++) {
+        const idx = gy * coarseW + gx;
+        if (!coarseRoadMask[idx]) {
+          handmadeCentersX[idx] = Number.NaN;
+          handmadeCentersY[idx] = Number.NaN;
+          handmadeStroke[idx] = 0;
+          continue;
+        }
+        const noiseValue = coarse[idx];
+        if (noiseValue <= noiseThreshold) {
+          handmadeCentersX[idx] = Number.NaN;
+          handmadeCentersY[idx] = Number.NaN;
+          handmadeStroke[idx] = 0;
+          continue;
+        }
+        const centerX = coarseCenters[idx * 2];
+        const centerY = coarseCenters[idx * 2 + 1];
+        if (!Number.isFinite(centerX) || !Number.isFinite(centerY)) {
+          handmadeCentersX[idx] = Number.NaN;
+          handmadeCentersY[idx] = Number.NaN;
+          handmadeStroke[idx] = 0;
+          continue;
+        }
+        const gridX = gridMinX + gx;
+        const jitterRadius = jitterBase * (0.65 + 0.35 * jitterFor(gridX, gridY, 19));
+        const jitterX = (jitterFor(gridX, gridY, 37) - 0.5) * jitterRadius;
+        const jitterY = (jitterFor(gridX, gridY, 71) - 0.5) * jitterRadius;
+        handmadeCentersX[idx] = centerX + jitterX;
+        handmadeCentersY[idx] = centerY + jitterY;
+        handmadeStroke[idx] = Math.max(0.35, Math.min(1.4, 0.55 + (noiseValue - noiseThreshold) * 1.8));
+        activeCells.push(idx);
+      }
+    }
+
     try {
-      // Clear overlay
       this._ctx.clearRect(0, 0, w, h);
       this._ctx.save();
-      // black fill style with desired alpha
-      const aNorm = (alpha / 255) || 0;
-      this._ctx.fillStyle = `rgba(0,0,0,${aNorm})`;
+      this._ctx.lineCap = 'round';
+      this._ctx.lineJoin = 'round';
+      this._ctx.strokeStyle = '#000000';
 
-      const drawW = Math.max(1, Math.ceil(pixelSizePx));
-      const drawH = Math.max(1, Math.ceil(pixelSizePx));
-      const halfW = drawW * 0.5;
-      const halfH = drawH * 0.5;
+      const offsets = [
+        { dx: 1, dy: 0, weight: 1 },
+        { dx: 0, dy: 1, weight: 1 },
+        { dx: 1, dy: 1, weight: 0.7 },
+      ];
 
-      for (let gy = 0; gy < coarseH; gy++) {
-        for (let gx = 0; gx < coarseW; gx++) {
-          const i = gy * coarseW + gx;
-          if (!coarseRoadMask[i]) continue; // skip non-road blocks
-          const n = coarse[i];
-          if (n <= noiseThreshold) continue;
-          const centerX = coarseCenters[i * 2];
-          const centerY = coarseCenters[i * 2 + 1];
-          if (!Number.isFinite(centerX) || !Number.isFinite(centerY)) continue;
-          if (centerX + halfW < minPx || centerX - halfW > maxPx || centerY + halfH < minPy || centerY - halfH > maxPy) continue;
-          const x0 = Math.round(centerX - halfW);
-          const y0 = Math.round(centerY - halfH);
-          this._ctx.fillRect(x0, y0, drawW, drawH);
+      for (const idx of activeCells) {
+        const gx = idx % coarseW;
+        const gy = Math.floor(idx / coarseW);
+        const originX = handmadeCentersX[idx];
+        const originY = handmadeCentersY[idx];
+        if (!Number.isFinite(originX) || !Number.isFinite(originY)) continue;
+        const originStrength = handmadeStroke[idx];
+        let connected = false;
+
+        for (const offset of offsets) {
+          const ngx = gx + offset.dx;
+          const ngy = gy + offset.dy;
+          if (ngx < 0 || ngy < 0 || ngx >= coarseW || ngy >= coarseH) continue;
+          const nIdx = ngy * coarseW + ngx;
+          const targetX = handmadeCentersX[nIdx];
+          const targetY = handmadeCentersY[nIdx];
+          if (!Number.isFinite(targetX) || !Number.isFinite(targetY)) continue;
+
+          const strokeStrength = (originStrength + handmadeStroke[nIdx]) * 0.5;
+          const width = strokeBase * strokeStrength * offset.weight;
+          const noiseMix = Math.max(noiseThreshold, (coarse[idx] + coarse[nIdx]) * 0.5);
+          const intensity = Math.max(0.1, Math.min(1, (noiseMix - noiseThreshold) * 2));
+
+          this._ctx.lineWidth = Math.max(0.6, width);
+          this._ctx.globalAlpha = Math.max(0.15, Math.min(1, aNorm * 0.6 + intensity * 0.45));
+
+          const dx = targetX - originX;
+          const dy = targetY - originY;
+          const dist = Math.hypot(dx, dy);
+          this._ctx.beginPath();
+          this._ctx.moveTo(originX, originY);
+          if (dist > 1e-3) {
+            const invDist = 1 / dist;
+            const perpX = -dy * invDist;
+            const perpY = dx * invDist;
+            const curveNoise = (jitterFor(gridMinX + gx + ngx, gridMinY + gy + ngy, 113) - 0.5) * jitterBase * 0.8 * offset.weight;
+            const ctrlX = (originX + targetX) * 0.5 + perpX * curveNoise;
+            const ctrlY = (originY + targetY) * 0.5 + perpY * curveNoise;
+            this._ctx.quadraticCurveTo(ctrlX, ctrlY, targetX, targetY);
+          } else {
+            this._ctx.lineTo(targetX, targetY);
+          }
+          this._ctx.stroke();
+          connected = true;
+        }
+
+        if (!connected) {
+          const soloAngle = jitterFor(gridMinX + gx, gridMinY + gy, 157) * Math.PI * 2;
+          const soloRadius = strokeBase * (0.6 + originStrength);
+          const dirX = Math.cos(soloAngle) * soloRadius * 0.5;
+          const dirY = Math.sin(soloAngle) * soloRadius * 0.5;
+          const wobble = (jitterFor(gridMinX + gx, gridMinY + gy, 199) - 0.5) * jitterBase;
+          const ctrlX = originX + Math.cos(soloAngle + Math.PI / 2) * wobble * 0.6;
+          const ctrlY = originY + Math.sin(soloAngle + Math.PI / 2) * wobble * 0.6;
+          this._ctx.lineWidth = Math.max(0.6, strokeBase * originStrength * 0.9);
+          this._ctx.globalAlpha = Math.max(0.2, Math.min(1, aNorm * 0.65 + originStrength * 0.35));
+          this._ctx.beginPath();
+          this._ctx.moveTo(originX - dirX, originY - dirY);
+          this._ctx.quadraticCurveTo(ctrlX, ctrlY, originX + dirX, originY + dirY);
+          this._ctx.stroke();
         }
       }
 
+      this._ctx.globalAlpha = 1;
       this._ctx.restore();
     } catch (e) {
-      // If rect drawing fails, clear canvas as a safe fallback
       try { this._ctx.clearRect(0, 0, w, h); } catch (e2) {}
     }
     // If requested, draw outlines around the road geometry intersecting noisy areas


### PR DESCRIPTION
## Summary
- replace the old pixel-fill crack rendering with jittered curved strokes so the overlay feels handmade instead of blocky
- derive deterministic jitter, stroke weights, and fallback strokes per cell to keep the crack network organic while staying performant
- refresh the overlay documentation to explain the new hand-drawn rendering approach

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d00f960c74832a99d34404bab440b9