### PR TITLE
Tighten crack overlay and simplify UI controls

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -15,7 +15,6 @@ import { CRACK_PATTERNS, CrackPatternAssignments } from '../lib/crackPatterns';
 type CrackRandomFlags = {
     color: boolean;
     alpha: boolean;
-    stroke: boolean;
     seedDensity: boolean;
     sampleAlong: boolean;
     sampleAcross: boolean;
@@ -263,7 +262,6 @@ const App: React.FC = () => {
     const [crackConfigOpen, setCrackConfigOpen] = useState<boolean>(false);
     const [crackColor, setCrackColor] = useState<string>(() => '#' + (((config as any).render.crackedRoadColor ?? 0x00E5FF).toString(16).padStart(6, '0')));
     const [crackAlpha, setCrackAlpha] = useState<number>(() => (config as any).render.crackedRoadAlpha ?? 0.88);
-    const [crackStrokePx, setCrackStrokePx] = useState<number>(() => (config as any).render.crackedRoadStrokePx ?? 1.35);
     const [crackSeedDensity, setCrackSeedDensity] = useState<number>(() => (config as any).render.crackedRoadSeedDensity ?? 0.055);
     const [crackSampleAlong, setCrackSampleAlong] = useState<number>(() => (config as any).render.crackedRoadSampleDensityAlong ?? 1.6);
     const [crackSampleAcross, setCrackSampleAcross] = useState<number>(() => (config as any).render.crackedRoadSampleDensityAcross ?? 1.1);
@@ -276,7 +274,6 @@ const App: React.FC = () => {
     const [crackRandomFlags, setCrackRandomFlags] = useState<CrackRandomFlags>({
         color: true,
         alpha: true,
-        stroke: true,
         seedDensity: true,
         sampleAlong: true,
         sampleAcross: true,
@@ -355,7 +352,6 @@ const App: React.FC = () => {
     const resetCrackConfig = () => {
         setCrackColor('#00e5ff');
         setCrackAlpha(0.88);
-        setCrackStrokePx(1.35);
         setCrackSeedDensity(0.055);
         setCrackSampleAlong(1.6);
         setCrackSampleAcross(1.1);
@@ -400,13 +396,6 @@ const App: React.FC = () => {
             setCrackAlpha(nextAlpha);
         }
         renderCfg.crackedRoadAlpha = Math.min(1, Math.max(0, nextAlpha));
-
-        let nextStroke = crackStrokePx;
-        if (flags.stroke) {
-            nextStroke = randomFloat(0.6, 2.4, 2);
-            setCrackStrokePx(nextStroke);
-        }
-        renderCfg.crackedRoadStrokePx = Math.max(0.05, nextStroke);
 
         let nextSeedDensity = crackSeedDensity;
         if (flags.seedDensity) {
@@ -597,7 +586,6 @@ const App: React.FC = () => {
             renderCfg.crackedRoadColor = parsedColor;
         }
         renderCfg.crackedRoadAlpha = Math.min(1, Math.max(0, crackAlpha));
-        renderCfg.crackedRoadStrokePx = Math.max(0.05, crackStrokePx);
         renderCfg.crackedRoadSeedDensity = Math.max(0.001, crackSeedDensity);
         renderCfg.crackedRoadSampleDensityAlong = Math.max(0.1, crackSampleAlong);
         renderCfg.crackedRoadSampleDensityAcross = Math.max(0.1, crackSampleAcross);
@@ -619,7 +607,6 @@ const App: React.FC = () => {
         crackSampleAlong,
         crackSampleAcross,
         crackSeedDensity,
-        crackStrokePx,
         crackThreshold,
         broadcastCrackedRoadConfigChange,
     ]);
@@ -1161,39 +1148,6 @@ const App: React.FC = () => {
                                     const raw = parseNumberInput(e.target.value);
                                     const nv = Number.isFinite(raw) ? Math.min(Math.max(raw, 0), 1) : 0.88;
                                     setCrackAlpha(nv);
-                                }}
-                                style={{
-                                    padding: '4px 6px',
-                                    borderRadius: 4,
-                                    border: '1px solid rgba(255,255,255,0.2)',
-                                    background: 'rgba(255,255,255,0.06)',
-                                    color: '#ECEFF1',
-                                }}
-                            />
-                        </div>
-                        <div style={{ display: 'flex', flexDirection: 'column', gap: 4 }}>
-                            <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
-                                <label htmlFor="crack-stroke" style={{ fontSize: 11, fontWeight: 600 }}>Espessura (px)</label>
-                                <label style={{ display: 'flex', alignItems: 'center', gap: 4, fontSize: 10, opacity: 0.75 }}>
-                                    <input
-                                        type="checkbox"
-                                        checked={crackRandomFlags.stroke}
-                                        onChange={() => toggleCrackRandomFlag('stroke')}
-                                        style={{ margin: 0 }}
-                                    />
-                                    Rand
-                                </label>
-                            </div>
-                            <input
-                                id="crack-stroke"
-                                type="number"
-                                min={0.05}
-                                step={0.05}
-                                value={crackStrokePx}
-                                onChange={(e) => {
-                                    const raw = parseNumberInput(e.target.value);
-                                    const nv = Number.isFinite(raw) ? Math.max(0.05, raw) : 1.35;
-                                    setCrackStrokePx(nv);
                                 }}
                                 style={{
                                     padding: '4px 6px',

--- a/src/game_modules/config.ts
+++ b/src/game_modules/config.ts
@@ -290,7 +290,6 @@ export const config = {
     showCrackedRoadsOutline: true,
     crackedRoadColor: 0x00E5FF,
     crackedRoadAlpha: 0.88,
-    crackedRoadStrokePx: 1.35,
     crackedRoadSeedDensity: 0.055,
     crackedRoadSampleDensityAlong: 1.6,
     crackedRoadSampleDensityAcross: 1.1,

--- a/src/overlays/NoiseZoning.ts
+++ b/src/overlays/NoiseZoning.ts
@@ -4,8 +4,9 @@
  * Modifications:
  * - Restrict rendering to road areas only by building a coarse road mask using the MapStore quadtree
  *   and distance-to-segment checks. This prevents the noise overlay from showing on non-road areas.
- * - Pixelate the noise by sampling at a coarse grid and using nearest-neighbor lookup when writing
- *   pixels. This gives a blocky/pixelated look instead of smooth organic interpolation.
+ * - Sample the noise on a coarse grid but render it using jittered curved strokes that connect
+ *   active cells. This preserves performance while replacing the previous blocky pixels with a
+ *   hand-drawn aesthetic that feels less digital.
  * API: attach(canvas), toggle(), reseed(), redraw()
  * Independent of roads/buildings
  */
@@ -586,40 +587,121 @@ const NoiseZoning: InternalNoiseZoning = {
     for (let i = 0; i < coarse.length; i++) {
       intersectionMask[i] = (coarse[i] > noiseThreshold && coarseRoadMask[i]) ? 1 : 0;
     }
-    // Pixelated rendering: draw one rect per coarse cell using nearest-neighbor.
-    // This avoids allocating a full ImageData buffer and reduces memory churn.
+    const aNorm = (alpha / 255) || 0;
+    const handmadeCentersX = new Float32Array(coarseW * coarseH);
+    const handmadeCentersY = new Float32Array(coarseW * coarseH);
+    const handmadeStroke = new Float32Array(coarseW * coarseH);
+    const activeCells: number[] = [];
+
+    const baseSeed = Math.floor((this as any)._handSeed ?? this._seed ?? 0);
+    (this as any)._handSeed = baseSeed;
+    const jitterBase = Math.max(0.35, pixelSizePx * 0.45);
+    const strokeBase = Math.max(0.75, pixelSizePx * 0.6);
+
+    const jitterFor = (gridX: number, gridY: number, variant: number) => {
+      const s = Math.sin((gridX * 127.1 + gridY * 311.7 + (baseSeed + variant) * 74.7) * 12.9898) * 43758.5453;
+      return s - Math.floor(s);
+    };
+
+    for (let gy = 0; gy < coarseH; gy++) {
+      const gridY = gridMinY + gy;
+      for (let gx = 0; gx < coarseW; gx++) {
+        const idx = gy * coarseW + gx;
+        if (!coarseRoadMask[idx]) {
+          handmadeCentersX[idx] = Number.NaN;
+          handmadeCentersY[idx] = Number.NaN;
+          handmadeStroke[idx] = 0;
+          continue;
+        }
+        const noiseValue = coarse[idx];
+        if (noiseValue <= noiseThreshold) {
+          handmadeCentersX[idx] = Number.NaN;
+          handmadeCentersY[idx] = Number.NaN;
+          handmadeStroke[idx] = 0;
+          continue;
+        }
+        const centerX = coarseCenters[idx * 2];
+        const centerY = coarseCenters[idx * 2 + 1];
+        if (!Number.isFinite(centerX) || !Number.isFinite(centerY)) {
+          handmadeCentersX[idx] = Number.NaN;
+          handmadeCentersY[idx] = Number.NaN;
+          handmadeStroke[idx] = 0;
+          continue;
+        }
+        const gridX = gridMinX + gx;
+        const jitterRadius = jitterBase * (0.65 + 0.35 * jitterFor(gridX, gridY, 19));
+        const jitterX = (jitterFor(gridX, gridY, 37) - 0.5) * jitterRadius;
+        const jitterY = (jitterFor(gridX, gridY, 71) - 0.5) * jitterRadius;
+        handmadeCentersX[idx] = centerX + jitterX;
+        handmadeCentersY[idx] = centerY + jitterY;
+        handmadeStroke[idx] = Math.max(0.35, Math.min(1.4, 0.55 + (noiseValue - noiseThreshold) * 1.8));
+        activeCells.push(idx);
+      }
+    }
+
     try {
-      // Clear overlay
       this._ctx.clearRect(0, 0, w, h);
       this._ctx.save();
-      // black fill style with desired alpha
-      const aNorm = (alpha / 255) || 0;
-      this._ctx.fillStyle = `rgba(0,0,0,${aNorm})`;
+      this._ctx.lineCap = 'round';
+      this._ctx.lineJoin = 'round';
+      this._ctx.strokeStyle = '#000000';
 
-      const drawW = Math.max(1, Math.ceil(pixelSizePx));
-      const drawH = Math.max(1, Math.ceil(pixelSizePx));
-      const halfW = drawW * 0.5;
-      const halfH = drawH * 0.5;
+      const offsets = [
+        { dx: 1, dy: 0, weight: 1 },
+        { dx: 0, dy: 1, weight: 1 },
+        { dx: 1, dy: 1, weight: 0.7 },
+      ];
 
-      for (let gy = 0; gy < coarseH; gy++) {
-        for (let gx = 0; gx < coarseW; gx++) {
-          const i = gy * coarseW + gx;
-          if (!coarseRoadMask[i]) continue; // skip non-road blocks
-          const n = coarse[i];
-          if (n <= noiseThreshold) continue;
-          const centerX = coarseCenters[i * 2];
-          const centerY = coarseCenters[i * 2 + 1];
-          if (!Number.isFinite(centerX) || !Number.isFinite(centerY)) continue;
-          if (centerX + halfW < minPx || centerX - halfW > maxPx || centerY + halfH < minPy || centerY - halfH > maxPy) continue;
-          const x0 = Math.round(centerX - halfW);
-          const y0 = Math.round(centerY - halfH);
-          this._ctx.fillRect(x0, y0, drawW, drawH);
+      for (const idx of activeCells) {
+        const gx = idx % coarseW;
+        const gy = Math.floor(idx / coarseW);
+        const originX = handmadeCentersX[idx];
+        const originY = handmadeCentersY[idx];
+        if (!Number.isFinite(originX) || !Number.isFinite(originY)) continue;
+        const originStrength = handmadeStroke[idx];
+
+        for (const offset of offsets) {
+          const ngx = gx + offset.dx;
+          const ngy = gy + offset.dy;
+          if (ngx < 0 || ngy < 0 || ngx >= coarseW || ngy >= coarseH) continue;
+          const nIdx = ngy * coarseW + ngx;
+          const targetX = handmadeCentersX[nIdx];
+          const targetY = handmadeCentersY[nIdx];
+          if (!Number.isFinite(targetX) || !Number.isFinite(targetY)) continue;
+
+          const strokeStrength = (originStrength + handmadeStroke[nIdx]) * 0.5;
+          const width = strokeBase * strokeStrength * offset.weight;
+          const noiseMix = Math.max(noiseThreshold, (coarse[idx] + coarse[nIdx]) * 0.5);
+          const intensity = Math.max(0.1, Math.min(1, (noiseMix - noiseThreshold) * 2));
+
+          this._ctx.lineWidth = Math.max(0.6, width);
+          this._ctx.globalAlpha = Math.max(0.15, Math.min(1, aNorm * 0.6 + intensity * 0.45));
+
+          const dx = targetX - originX;
+          const dy = targetY - originY;
+          const dist = Math.hypot(dx, dy);
+          const minSpan = Math.max(pixelSizePx * 0.25, strokeBase * 0.35);
+          if (dist < minSpan) continue;
+          this._ctx.beginPath();
+          this._ctx.moveTo(originX, originY);
+          if (dist > 1e-3) {
+            const invDist = 1 / dist;
+            const perpX = -dy * invDist;
+            const perpY = dx * invDist;
+            const curveNoise = (jitterFor(gridMinX + gx + ngx, gridMinY + gy + ngy, 113) - 0.5) * jitterBase * 0.8 * offset.weight;
+            const ctrlX = (originX + targetX) * 0.5 + perpX * curveNoise;
+            const ctrlY = (originY + targetY) * 0.5 + perpY * curveNoise;
+            this._ctx.quadraticCurveTo(ctrlX, ctrlY, targetX, targetY);
+          } else {
+            this._ctx.lineTo(targetX, targetY);
+          }
+          this._ctx.stroke();
         }
       }
 
+      this._ctx.globalAlpha = 1;
       this._ctx.restore();
     } catch (e) {
-      // If rect drawing fails, clear canvas as a safe fallback
       try { this._ctx.clearRect(0, 0, w, h); } catch (e2) {}
     }
     // If requested, draw outlines around the road geometry intersecting noisy areas


### PR DESCRIPTION
## Summary
- remove the fallback solo strokes and ignore very short segments so the crack overlay no longer leaves dotted artifacts
- simplify the cracked-road configuration panel to only expose parameters that still affect rendering, dropping the unused thickness control and randomization flag
- drop the unused crackedRoadStrokePx default from the shared render config

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d00f960c74832a99d34404bab440b9