### PR TITLE
Tune handmade crack overlay controls

### DIFF
--- a/src/game_modules/config.ts
+++ b/src/game_modules/config.ts
@@ -301,6 +301,9 @@ export const config = {
     crackedRoadMaxSamplesAcross: 96,
     crackedRoadProbeStepM: 1.1,
     crackedRoadPatternAssignments: null as null | { version: number; segments: Record<string, string> },
+    crackedRoadHandmadeCellPx: 4,
+    crackedRoadHandmadeNoiseThreshold: 0.52,
+    crackedRoadHandmadeJitter: 1.0,
     // Mostrar apenas os contornos dos quarteirões (esconde ruas e preenchimento dos prédios)
     showOnlyBlockOutlines: false,
     // Mostrar apenas o interior dos quarteirões (preenchidos), escondendo ruas e demais elementos


### PR DESCRIPTION
## Summary
- add dedicated configuration defaults for handmade crack cell size, noise threshold, and jitter
- align the NoiseZoning overlay with the configurable color, opacity, stroke, cell size, and jitter while rejecting short segments to eliminate stray dots
- streamline the cracked roads control panel to the new parameters and update reset/randomize flows to drive the overlay through NoiseZoning

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d00f960c74832a99d34404bab440b9