### PR TITLE
Improve cracked road texture quality

### DIFF
--- a/src/game_modules/config.ts
+++ b/src/game_modules/config.ts
@@ -291,6 +291,7 @@ export const config = {
     crackedRoadColor: 0x00E5FF,
     crackedRoadAlpha: 0.88,
     crackedRoadStrokePx: 1.35,
+    crackedRoadResolutionMultiplier: 3.0,
     crackedRoadSeedDensity: 0.055,
     crackedRoadSampleDensityAlong: 1.6,
     crackedRoadSampleDensityAcross: 1.1,

--- a/src/lib/crackPatterns.ts
+++ b/src/lib/crackPatterns.ts
@@ -8,6 +8,7 @@ export interface CrackPatternMultipliers {
     maxSamplesAcross?: number;
     probeStep?: number;
     strokePx?: number;
+    resolutionMultiplier?: number;
     alpha?: number;
 }
 


### PR DESCRIPTION
## Summary
- supersample crack sprites with configurable stroke width to render smoother fissures
- soften crack rasterization edges and switch textures to linear filtering with mipmaps
- expose a cracked road resolution multiplier in render config for future tuning

## Testing
- npm run build


------
https://chatgpt.com/codex/tasks/task_e_68d01ed9ab28832aa3762787cb4994ef