### PR TITLE
Do not force Perlin noise overlay when enabling cracked roads

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -711,9 +711,6 @@ const App: React.FC = () => {
                                 try { (config as any).render.showLaneOutlines = false; } catch (e) {}
                                 setLaneOutlinesEnabled(false);
                             }
-                            if (!noiseOverlayVisible) {
-                                setNoiseOverlayVisible(true);
-                            }
                         } else if (laneOutlinePrevRef.current !== null) {
                             const restore = laneOutlinePrevRef.current;
                             laneOutlinePrevRef.current = null;


### PR DESCRIPTION
## Summary
- stop enabling the Perlin noise overlay when toggling cracked roads on so only the crack sprites are shown

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d02326bda8832a9ab77abe7678f7de