### PR TITLE
Adjust crack generation to Voronoi-style edges

### DIFF
--- a/src/components/GameCanvas.tsx
+++ b/src/components/GameCanvas.tsx
@@ -151,18 +151,10 @@ const generateRoadCrackSprite = ({
     const spanScaleY = expandedSpanY / pixelRows;
     if (!(spanScaleX > 0) || !(spanScaleY > 0)) return null;
 
-    const spanScaleXAbs = Math.max(Math.abs(spanScaleX), 1e-4);
-    const spanScaleYAbs = Math.max(Math.abs(spanScaleY), 1e-4);
     const strokeWidthPx = Math.max(0.35, Number.isFinite(strokePx) ? strokePx : 1);
-    const isoRadiusX = Math.max(spanScaleXAbs * strokeWidthPx * 0.5, spanScaleXAbs * 0.5);
-    const isoRadiusY = Math.max(spanScaleYAbs * strokeWidthPx * 0.5, spanScaleYAbs * 0.5);
-    const invIsoRadiusXSq = isoRadiusX > 1e-6 ? 1 / (isoRadiusX * isoRadiusX) : 0;
-    const invIsoRadiusYSq = isoRadiusY > 1e-6 ? 1 / (isoRadiusY * isoRadiusY) : 0;
-    const pxRadius = Math.max(1, Math.ceil(strokeWidthPx * supersample * 0.5 + 1));
-    const softEdgeNorm = Math.min(0.65, Math.max(0.18, 0.9 / (strokeWidthPx * supersample + 1e-3)));
-    const edgeEpsilon = 0.12;
-
     const epsilonWorld = Math.max(1e-6, epsilonPx);
+    const featherWidth = epsilonWorld * (0.12 + Math.max(0, strokeWidthPx - 0.35) * 0.22);
+    const softThreshold = epsilonWorld + featherWidth;
 
     const targetSeeds = Math.max(2, Math.min(4096, Math.floor(seedCount)));
     const worldSeeds: number[] = [];
@@ -205,40 +197,6 @@ const generateRoadCrackSprite = ({
     const buffer = new Uint8Array(pixelCols * pixelRows * 4);
     const candidateBuf: number[] = [];
     let hits = 0;
-
-    const paintDisc = (cx: number, cy: number) => {
-        const minY = Math.max(0, Math.floor(cy - pxRadius));
-        const maxY = Math.min(pixelRows - 1, Math.ceil(cy + pxRadius));
-        const minX = Math.max(0, Math.floor(cx - pxRadius));
-        const maxX = Math.min(pixelCols - 1, Math.ceil(cx + pxRadius));
-        const falloffStart = 1 - softEdgeNorm;
-        const falloffEnd = 1 + edgeEpsilon;
-        const denom = Math.max(1e-4, falloffEnd - falloffStart);
-        for (let yy = minY; yy <= maxY; yy++) {
-            const dy = yy - cy;
-            for (let xx = minX; xx <= maxX; xx++) {
-                const dx = xx - cx;
-                const dxIso = dx * spanScaleX;
-                const dyIso = dy * spanScaleY;
-                let norm = 0;
-                if (invIsoRadiusXSq > 0) norm += dxIso * dxIso * invIsoRadiusXSq;
-                if (invIsoRadiusYSq > 0) norm += dyIso * dyIso * invIsoRadiusYSq;
-                const distNorm = Math.sqrt(Math.max(0, norm));
-                if (distNorm >= falloffEnd) continue;
-                let weight = 1;
-                if (distNorm > falloffStart) {
-                    weight = Math.max(0, Math.min(1, (falloffEnd - distNorm) / denom));
-                }
-                if (weight <= 0) continue;
-                const idx = (yy * pixelCols + xx) * 4;
-                const alphaByte = Math.max(buffer[idx + 3], Math.round(weight * 255));
-                buffer[idx] = 255;
-                buffer[idx + 1] = 255;
-                buffer[idx + 2] = 255;
-                buffer[idx + 3] = alphaByte;
-            }
-        }
-    };
 
     for (let py = 0; py < pixelRows; py++) {
         const isoY = isoOriginY + (py + 0.5) * spanScaleY;
@@ -289,8 +247,21 @@ const generateRoadCrackSprite = ({
             if (!Number.isFinite(best1) || !Number.isFinite(best2) || best2 === Infinity) continue;
 
             const delta = Math.sqrt(best2) - Math.sqrt(best1);
-            if (delta < epsilonWorld) {
-                paintDisc(px, py);
+            if (delta < softThreshold) {
+                const idx = (py * pixelCols + px) * 4;
+                let weight = 1;
+                if (delta > epsilonWorld) {
+                    const falloff = softThreshold - epsilonWorld;
+                    if (falloff > 1e-6) {
+                        weight = Math.max(0, Math.min(1, 1 - (delta - epsilonWorld) / falloff));
+                    }
+                }
+                const prevAlpha = buffer[idx + 3];
+                const alphaByte = Math.max(prevAlpha, Math.round(weight * 255));
+                buffer[idx] = 255;
+                buffer[idx + 1] = 255;
+                buffer[idx + 2] = 255;
+                buffer[idx + 3] = alphaByte;
                 hits++;
             }
         }


### PR DESCRIPTION
## Summary
- update the cracked road sprite generator to color Voronoi edges directly instead of dilating discs
- derive a soft threshold from the epsilon and stroke width so the cracks stay thin while retaining adjustable softness

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d130611edc832a85aac5ff73fb4398