### PR TITLE
Add UI for sidewalk texture upload

### DIFF
--- a/src/game_modules/config.ts
+++ b/src/game_modules/config.ts
@@ -419,6 +419,12 @@ export const config = {
     blockInteriorTextureAlpha: 1.0,
     // Escala aplicada na Matrix do beginTextureFill (1.0 = tamanho original). Valores maiores => textura "mais grossa".
     blockInteriorTextureScale: 1.0,
+    // ================== Textura Calçada (Região Central) ==================
+    // Textura opcional aplicada na região central (heatmap) representando calçadas/pisos especiais.
+    sidewalkUseTexture: false,
+    sidewalkTextureTint: 0xFFFFFF,
+    sidewalkTextureAlpha: 1.0,
+    sidewalkTextureScale: 1.0,
     },
     gameLogic: {
         SELECT_PAN_THRESHOLD: 50, // px


### PR DESCRIPTION
## Summary
- add new "Textura Calçada" controls for uploading and configuring sidewalk textures in the main UI
- plumb sidewalk texture data through GameCanvas and remove reliance on the procedural tile generator
- extend render configuration defaults with sidewalk texture settings for persistence

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4471d48a4832ab983336f13afd69c