### PR TITLE
Add UI to upload custom sidewalk texture

### DIFF
--- a/src/game_modules/config.ts
+++ b/src/game_modules/config.ts
@@ -419,6 +419,10 @@ export const config = {
     blockInteriorTextureAlpha: 1.0,
     // Escala aplicada na Matrix do beginTextureFill (1.0 = tamanho original). Valores maiores => textura "mais grossa".
     blockInteriorTextureScale: 1.0,
+    // Textura opcional para calçadas/centro (heatmap) carregada via UI
+    sidewalkUseTexture: false,
+    sidewalkTextureScale: 1.0,
+    sidewalkTextureAlpha: 1.0,
     },
     gameLogic: {
         SELECT_PAN_THRESHOLD: 50, // px


### PR DESCRIPTION
## Summary
- add new UI controls to upload and configure the "Textura Calçada" sidewalk texture
- update the rendering pipeline to use the uploaded sidewalk texture instead of the procedural tile generator
- extend rendering config with sidewalk texture flags for persistence

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d4471d48a4832ab983336f13afd69c