### PR TITLE
Adjust sidewalks to block shape within heatmap radius

### DIFF
--- a/src/components/GameCanvas.tsx
+++ b/src/components/GameCanvas.tsx
@@ -3120,7 +3120,10 @@ const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interi
                                 // Converter polígono do quarteirão para Clipper paths
                                 const outerPath = worldPts.map(p => ({ X: Math.round(p.x * CLIP_SCALE), Y: Math.round(p.y * CLIP_SCALE) }));
                                 const coSide = new ClipperLib.ClipperOffset();
-                                coSide.AddPath(outerPath, ClipperLib.JoinType.jtRound, ClipperLib.EndType.etClosedPolygon);
+                                const joinType = inside
+                                    ? ClipperLib.JoinType.jtMiter
+                                    : ClipperLib.JoinType.jtRound;
+                                coSide.AddPath(outerPath, joinType, ClipperLib.EndType.etClosedPolygon);
                                 const innerPaths = new ClipperLib.Paths();
                                 // Offset negativo para dentro do quarteirão
                                 coSide.Execute(innerPaths, -widthM * CLIP_SCALE);


### PR DESCRIPTION
## Summary
- switch the sidewalk offset join type to miter for blocks inside the heatmap radius so the ring matches block geometry

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5684d45cc832a83234eb2688fbfca