### PR TITLE
Add decorative street props to city generation

### DIFF
--- a/src/components/GameCanvas.tsx
+++ b/src/components/GameCanvas.tsx
@@ -2387,6 +2387,17 @@ const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interi
                     segment, count, radius, qTree!, getZoneAt, timeNow
                 );
             }
+            const decorExisting = buildings.concat(newBuildings);
+            const decorations = buildingFactory.streetFurnitureAlongSegment(
+                segment,
+                qTree!,
+                decorExisting,
+                getZoneAt,
+                timeNow
+            );
+            if (decorations.length) {
+                decorations.forEach(b => newBuildings.push(b));
+            }
             newBuildings.forEach(b => qTree!.insert(b.collider.limits()));
             buildings = buildings.concat(newBuildings);
         }
@@ -2535,6 +2546,11 @@ const GameCanvas: React.FC<GameCanvasPropsInternal> = ({ interiorTexture, interi
                 park: 0xC8E6C9,
                 church: 0xD1C4E9,
                 import: 0xCE93D8,
+                streetTree: 0x66BB6A,
+                treeCluster: 0x4CAF50,
+                lampPost: 0xB0BEC5,
+                trashBin: 0x8D6E63,
+                bench: 0xA1887F,
                 factory: 0xB39DDB,
                 warehouseSmall: 0xB0A8D9,
                 factoryMedium: 0x9E9DCD,

--- a/src/game_modules/build.ts
+++ b/src/game_modules/build.ts
@@ -61,6 +61,11 @@ export enum BuildingType {
     COOPERATIVE = "cooperative",
     FIELD = "field",
     POND = "pond",
+    STREET_TREE = "streetTree",
+    TREE_CLUSTER = "treeCluster",
+    LAMP_POST = "lampPost",
+    TRASH_BIN = "trashBin",
+    BENCH = "bench",
 }
 
 export class Building {
@@ -124,24 +129,24 @@ export const buildingFactory = {
             downtown: [
                 'shoppingCenter','office','hotel','office','conventionCenter','cinema','hospitalPrivate','clinic','publicOffice',
                 'commercialLarge','commercialMedium','commercial','supermarket','grocery','restaurant','bakery','bar','pharmacy','shopSmall','kiosk',
-                'bank','parkingLot','gasStation','residential','house','park','green','church'
+                'bank','parkingLot','gasStation','residential','house','park','green','church','streetTree','treeCluster','lampPost','trashBin','bench'
             ] as any,
             commercial: [
                 'kiosk','shopSmall','bakery','bar','pharmacy','grocery','restaurant','supermarket','shoppingCenter','office','hotel','parkingLot',
                 'bank','gasStation','commercial','commercialMedium','commercialLarge','cinema','clinic','hospitalPrivate','publicOffice','conventionCenter',
                 // Residencial leve permitido na comercial
-                'residential','houseSmall','house','apartmentBlock'
+                'residential','houseSmall','house','apartmentBlock','streetTree','treeCluster','lampPost','trashBin','bench'
             ] as any,
             residential: [
                 'houseSmall','house','houseHigh','apartmentBlock','condoTower','school','leisureArea',
-                'park','green','church','clinic'
+                'park','green','church','clinic','streetTree','treeCluster','lampPost','trashBin','bench'
             ] as any,
             industrial: [
                 'workshop','warehouseSmall','factory','factoryMedium','distributionCenter','industrialComplex','powerPlant',
-                'commercialMedium'
+                'commercialMedium','streetTree','lampPost','trashBin','bench'
             ] as any,
             rural: [
-                'farm','farmhouse','silo','animalBarn','machineryShed','cooperative','field','pond'
+                'farm','farmhouse','silo','animalBarn','machineryShed','cooperative','field','pond','streetTree','treeCluster','bench','trashBin'
             ] as any,
         } as any;
         const allowed = new Set((allowByZone as any)[zone] || []);
@@ -181,6 +186,11 @@ export const buildingFactory = {
             // Áreas comuns
             { t: BuildingType.PARK, k: 'park' },
             { t: BuildingType.GREEN, k: 'green' },
+            { t: BuildingType.STREET_TREE, k: 'streetTree' },
+            { t: BuildingType.TREE_CLUSTER, k: 'treeCluster' },
+            { t: BuildingType.LAMP_POST, k: 'lampPost' },
+            { t: BuildingType.TRASH_BIN, k: 'trashBin' },
+            { t: BuildingType.BENCH, k: 'bench' },
             { t: BuildingType.CHURCH, k: 'church' },
             { t: BuildingType.IMPORT, k: 'import' },
             // Industrial
@@ -651,6 +661,51 @@ export const buildingFactory = {
                     building = new Building({ x: 0, y: 0 }, 0, diag, BuildingType.POND, ar);
                 }
                 break;
+            case BuildingType.STREET_TREE:
+                {
+                    const dims = (config.buildings as any).dimensions.streetTree;
+                    const scale = math.randomRange(0.85, 1.25);
+                    const diag = Math.hypot(dims.width, dims.depth) / 2 * Math.sqrt(config.buildings.areaScale) * scale;
+                    const ar = (dims.width / dims.depth) * math.randomRange(0.8, 1.25);
+                    building = new Building({ x: 0, y: 0 }, 0, diag, BuildingType.STREET_TREE, ar);
+                }
+                break;
+            case BuildingType.TREE_CLUSTER:
+                {
+                    const dims = (config.buildings as any).dimensions.treeCluster;
+                    const scale = math.randomRange(0.9, 1.3);
+                    const diag = Math.hypot(dims.width, dims.depth) / 2 * Math.sqrt(config.buildings.areaScale) * scale;
+                    const ar = (dims.width / dims.depth) * math.randomRange(0.85, 1.2);
+                    building = new Building({ x: 0, y: 0 }, 0, diag, BuildingType.TREE_CLUSTER, ar);
+                }
+                break;
+            case BuildingType.LAMP_POST:
+                {
+                    const dims = (config.buildings as any).dimensions.lampPost;
+                    const scale = math.randomRange(0.8, 1.1);
+                    const diag = Math.hypot(dims.width, dims.depth) / 2 * Math.sqrt(config.buildings.areaScale) * scale;
+                    const ar = (dims.width / Math.max(0.1, dims.depth)) * math.randomRange(0.95, 1.1);
+                    building = new Building({ x: 0, y: 0 }, 0, Math.max(diag, 0.4), BuildingType.LAMP_POST, ar);
+                }
+                break;
+            case BuildingType.TRASH_BIN:
+                {
+                    const dims = (config.buildings as any).dimensions.trashBin;
+                    const scale = math.randomRange(0.85, 1.2);
+                    const diag = Math.hypot(dims.width, dims.depth) / 2 * Math.sqrt(config.buildings.areaScale) * scale;
+                    const ar = (dims.width / Math.max(0.1, dims.depth)) * math.randomRange(0.9, 1.2);
+                    building = new Building({ x: 0, y: 0 }, 0, Math.max(diag, 0.45), BuildingType.TRASH_BIN, ar);
+                }
+                break;
+            case BuildingType.BENCH:
+                {
+                    const dims = (config.buildings as any).dimensions.bench;
+                    const scale = math.randomRange(0.9, 1.1);
+                    const diag = Math.hypot(dims.width, dims.depth) / 2 * Math.sqrt(config.buildings.areaScale) * scale;
+                    const ar = (dims.width / Math.max(0.1, dims.depth)) * math.randomRange(0.95, 1.15);
+                    building = new Building({ x: 0, y: 0 }, 0, Math.max(diag, 0.6), BuildingType.BENCH, ar);
+                }
+                break;
         }
         return building;
     },
@@ -1039,5 +1094,99 @@ export const buildingFactory = {
             }
         }
         return buildings;
+    },
+
+    streetFurnitureAlongSegment(
+        segment: Segment,
+        quadtree: Quadtree,
+        existingBuildings: Building[],
+        zoneAt: (p: math.Point) => ZoneName = getZoneAt,
+        time: number = Date.now()
+    ): Building[] {
+        const zone = zoneAt(segment.r.end);
+        const zoneCfg = ((config as any).zones?.[zone] || {}) as any;
+        const decorCfg = zoneCfg?.decor;
+        if (!decorCfg) return [];
+        const mixEntries = Object.entries(decorCfg.mix || {}).filter(([, weight]) => Number(weight) > 0)
+            .map(([key, weight]) => ({ key, weight: Number(weight) }));
+        if (!mixEntries.length) return [];
+        const totalWeight = mixEntries.reduce((acc, entry) => acc + entry.weight, 0);
+        if (!(totalWeight > 0)) return [];
+
+        const pickType = (): BuildingType | null => {
+            let r = Math.random() * totalWeight;
+            for (const entry of mixEntries) {
+                r -= entry.weight;
+                if (r <= 0) return entry.key as BuildingType;
+            }
+            return mixEntries[mixEntries.length - 1].key as BuildingType;
+        };
+
+        const spacing = Math.max(6, Number(decorCfg.spacingM ?? 18));
+        const offsetBase = Number.isFinite(decorCfg.offsetM) ? Number(decorCfg.offsetM) : 2.0;
+        const density = Math.max(0, Math.min(1, Number(decorCfg.density ?? 0.75)));
+        const alongJitter = Math.max(0, Number(decorCfg.alongJitterM ?? 1.2));
+        const sideJitter = Math.max(0, Number(decorCfg.sideJitterM ?? 0.6));
+        const offsetJitter = Math.max(0, Number(decorCfg.offsetJitterM ?? 0.4));
+        const depthFactor = Number.isFinite(decorCfg.depthFactor) ? Number(decorCfg.depthFactor) : 0.5;
+        const marginCfg = Number.isFinite(decorCfg.marginM) ? Number(decorCfg.marginM) : undefined;
+
+        const placeBothSides = decorCfg.placeBothSides !== false;
+        const preferredSide = decorCfg.preferredSide === 'left' ? 1 : -1;
+        const sides: Array<1 | -1> = placeBothSides ? [-1, 1] : [preferredSide as 1 | -1];
+
+        const s = segment.r.start;
+        const e = segment.r.end;
+        const vx = e.x - s.x;
+        const vy = e.y - s.y;
+        const len = Math.hypot(vx, vy) || 1;
+        const ux = vx / len;
+        const uy = vy / len;
+        const nx = -uy;
+        const ny = ux;
+        const margin = Math.max(4, Math.min(len / 2, marginCfg ?? Math.max(4, spacing * 0.5)));
+        if (len <= margin * 2) return [];
+
+        const results: Building[] = [];
+        for (let base = margin; base <= len - margin; base += spacing) {
+            const tBase = base + math.randomRange(-alongJitter, alongJitter);
+            const t = Math.max(margin, Math.min(len - margin, tBase));
+            const pointOnSeg: math.Point = { x: s.x + ux * t, y: s.y + uy * t };
+            for (const side of sides) {
+                if (Math.random() > density) continue;
+                const type = pickType();
+                if (!type) continue;
+                const building = this.byType(type, time + results.length + (side > 0 ? 0 : 1000));
+                if (!building) continue;
+                building.setDir(segment.dir());
+                const halfAcross = building.diagonal * math.sinDegrees(building.aspectDegree);
+                const offset = (segment.width / 2) + Math.max(0.4, offsetBase) + Math.max(0, halfAcross * Math.max(0, depthFactor)) + math.randomRange(-offsetJitter, offsetJitter);
+                const cx = pointOnSeg.x + nx * offset * side + math.randomRange(-sideJitter, sideJitter);
+                const cy = pointOnSeg.y + ny * offset * side + math.randomRange(-sideJitter, sideJitter);
+                building.setCenter({ x: cx, y: cy });
+
+                const bounds = building.collider.limits();
+                const qCandidates: any[] = quadtree.retrieve(bounds) || [];
+                const nearExisting = existingBuildings.filter(ob => {
+                    const lim = ob.collider.limits();
+                    return !(lim.x + lim.width < bounds.x || bounds.x + bounds.width < lim.x || lim.y + lim.height < bounds.y || bounds.y + bounds.height < lim.y);
+                });
+                let collision = false;
+                for (const obj of qCandidates) {
+                    const other = (obj as any).o || obj;
+                    if (!other || other === building || !(other as any).collider) continue;
+                    if (building.collider.collide((other as any).collider)) { collision = true; break; }
+                }
+                if (collision) continue;
+                for (const other of [...nearExisting, ...results]) {
+                    if (other === building) continue;
+                    if (building.collider.collide(other.collider)) { collision = true; break; }
+                }
+                if (!collision) {
+                    results.push(building);
+                }
+            }
+        }
+        return results;
     }
 };

--- a/src/game_modules/config.ts
+++ b/src/game_modules/config.ts
@@ -198,6 +198,11 @@ export const config = {
             cooperative: { width: 40, depth: 70 },     // 2800 m²
             field: { width: 100, depth: 150 },         // 15.000 m² (um talhão)
             pond: { width: 40, depth: 60 },            // 2400 m²
+            streetTree: { width: 3, depth: 3 },        // árvore isolada
+            treeCluster: { width: 6, depth: 6 },       // grupo pequeno de árvores
+            lampPost: { width: 1, depth: 1 },          // poste urbano
+            trashBin: { width: 1.2, depth: 1.2 },      // lixeira
+            bench: { width: 2, depth: 1.2 },           // banco de praça
         }
     },
     render: {
@@ -501,6 +506,22 @@ export const config = {
             density: 10,
             scatterRadiusM: 140,
             coverageTarget: 0.40,
+            decor: {
+                spacingM: 18,
+                offsetM: 3,
+                density: 0.75,
+                alongJitterM: 1.2,
+                sideJitterM: 0.6,
+                offsetJitterM: 0.4,
+                depthFactor: 0.4,
+                mix: {
+                    streetTree: 0.28,
+                    treeCluster: 0.08,
+                    lampPost: 0.40,
+                    trashBin: 0.14,
+                    bench: 0.10,
+                }
+            }
         },
         residential: {
             blockLengthM: 100,
@@ -520,6 +541,22 @@ export const config = {
                 frontSetbackM: 5,
                 sideSetbackM: 1.5,
                 rearSetbackM: 6,
+            },
+            decor: {
+                spacingM: 16,
+                offsetM: 4,
+                density: 0.85,
+                alongJitterM: 1.8,
+                sideJitterM: 0.8,
+                offsetJitterM: 0.6,
+                depthFactor: 0.6,
+                mix: {
+                    streetTree: 0.50,
+                    treeCluster: 0.20,
+                    lampPost: 0.15,
+                    trashBin: 0.05,
+                    bench: 0.10,
+                }
             }
         },
         commercial: {
@@ -539,6 +576,22 @@ export const config = {
             density: 12,
             scatterRadiusM: 100,
             coverageTarget: 0.42,
+            decor: {
+                spacingM: 18,
+                offsetM: 3,
+                density: 0.8,
+                alongJitterM: 1.2,
+                sideJitterM: 0.5,
+                offsetJitterM: 0.5,
+                depthFactor: 0.45,
+                mix: {
+                    streetTree: 0.30,
+                    treeCluster: 0.10,
+                    lampPost: 0.35,
+                    trashBin: 0.15,
+                    bench: 0.10,
+                }
+            }
         },
         industrial: {
             blockLengthM: 140,
@@ -554,6 +607,21 @@ export const config = {
             coverageTarget: 0.22,
             // Afastamento mínimo entre fábricas (m)
             minFactorySpacingM: 200,
+            decor: {
+                spacingM: 28,
+                offsetM: 5,
+                density: 0.45,
+                alongJitterM: 1.5,
+                sideJitterM: 0.7,
+                offsetJitterM: 0.7,
+                depthFactor: 0.3,
+                mix: {
+                    streetTree: 0.20,
+                    lampPost: 0.45,
+                    trashBin: 0.25,
+                    bench: 0.10,
+                }
+            }
         },
         rural: {
             blockLengthM: 190,
@@ -567,6 +635,21 @@ export const config = {
             density: 2,
             scatterRadiusM: 180,
             coverageTarget: 0.06,
+            decor: {
+                spacingM: 30,
+                offsetM: 6,
+                density: 0.6,
+                alongJitterM: 2.5,
+                sideJitterM: 1.2,
+                offsetJitterM: 0.8,
+                depthFactor: 0.7,
+                mix: {
+                    streetTree: 0.45,
+                    treeCluster: 0.35,
+                    bench: 0.10,
+                    trashBin: 0.10,
+                }
+            }
         }
     }
 };


### PR DESCRIPTION
## Summary
- add new building types representing street trees, lampposts, benches, and trash bins with rendering colors
- configure zone-specific decoration mixes to control furniture spacing and density across districts
- generate street furniture along segments after building placement so props fill sidewalks organically

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d5b2166644832aa72a4c530b3907de